### PR TITLE
Completely configure golangci and enable workflow

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -26,6 +26,21 @@ on:
       - "api/**"
 
 jobs:
+  linting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Lint using Golanci lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          working-directory: api
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: write
+
   build_and_push:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/conversion.yml
+++ b/.github/workflows/conversion.yml
@@ -26,6 +26,21 @@ on:
       - "conversion/**"
 
 jobs:
+  linting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Lint using Golanci lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          working-directory: conversion
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: write
+
   build_and_push:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/mosaic.yml
+++ b/.github/workflows/mosaic.yml
@@ -26,6 +26,21 @@ on:
       - "mosaic/**"
 
 jobs:
+  linting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Lint using Golanci lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          working-directory: mosaic
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: write
+
   build_and_push:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -26,6 +26,21 @@ on:
       - "ui/**"
 
 jobs:
+  linting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Lint using Golanci lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          working-directory: ui
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: write
+
   build_and_push:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Add dummy embedded files
+        run: |
+          mkdir ui/dist
+          touch ui/dist/index.html
+
       - name: Lint using Golanci lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/api/.golangci.yml
+++ b/api/.golangci.yml
@@ -1,0 +1,139 @@
+---
+linters:
+  enable-all: true
+  disable:
+    - exhaustruct    # Structs may be uninitialized
+    - nlreturn       # covered by wsl cuddle rules
+    - nonamedreturns # named returns are acceptable
+    - depguard       # no dependency management
+    # deprecated
+    - execinquery
+    - gomnd
+    # To fix ###############################################
+    - wsl
+    - wrapcheck
+    - tagliatelle
+    - stylecheck
+    - perfsprint
+    - noctx
+    - nilerr
+    - ireturn
+    - usestdlibvars
+    - nilnil
+    - inamedparam
+    - govet
+    - mnd
+    - err113
+    - gochecknoglobals
+    - forcetypeassert
+    - errorlint
+    - dupword
+    - cyclop
+    - asasalint
+    - bodyclose
+    - unparam
+    - tagalign
+    - revive
+    - predeclared
+    - interfacebloat
+    - errname
+    - prealloc
+    - nestif
+    - lll
+    - gosec
+    - gofumpt
+    - godot
+    - gocritic
+    - gocognit
+    - gci
+    - funlen
+    - forbidigo
+    - errcheck
+    - gocyclo
+    - dupl
+    - maintidx
+
+severity:
+  default-severity: major
+
+issues:
+  fast: false
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  exclude-use-default: false
+  exclude-case-sensitive: true
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - errcheck
+        - errchkjson
+        - funlen
+        - gochecknoglobals
+        - goconst
+        - wrapcheck
+
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/kouprlabs)
+      - prefix(github.com/kouprlabs/voltaserve)
+
+  mnd:
+    ignored-numbers: ['2', '4', '8', '16', '32', '64', '10', '100', '1000']
+
+  gosec:
+    excludes:
+      - G104  # Errors unhandled. Already covered by errcheck linter.
+      - G307  # Deferring a method which returns an error. Already covered by errcheck linter.
+      - G601  # No longer applicable since go v1.22 update to for loops.
+
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment  # misalignment is accepted
+
+  revive:
+    # see https://github.com/mgechev/revive#recommended-configuration
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+
+  stylecheck:
+    checks: [all]
+
+  tagliatelle:
+    case:
+      rules:
+        json: goCamel
+        yaml: goSnake
+
+  varnamelen:
+    min-name-length: 1
+
+  wsl:
+    force-err-cuddling: true
+

--- a/conversion/.golangci.yml
+++ b/conversion/.golangci.yml
@@ -1,0 +1,132 @@
+---
+linters:
+  enable-all: true
+  disable:
+    - exhaustruct    # Structs may be uninitialized
+    - nlreturn       # covered by wsl cuddle rules
+    - nonamedreturns # named returns are acceptable
+    - depguard       # no dependency management
+    # deprecated
+    - execinquery
+    - gomnd
+    # To fix ###############################################
+    - wsl
+    - wrapcheck
+    - tagliatelle
+    - stylecheck
+    - perfsprint
+    - noctx
+    - nilerr
+    - ireturn
+    - usestdlibvars
+    - nilnil
+    - inamedparam
+    - govet
+    - mnd
+    - err113
+    - gochecknoglobals
+    - forcetypeassert
+    - errorlint
+    - dupword
+    - cyclop
+    - bodyclose
+    - revive
+    - errname
+    - prealloc
+    - nestif
+    - lll
+    - gosec
+    - gofumpt
+    - godot
+    - gocritic
+    - gocognit
+    - gci
+    - funlen
+    - errcheck
+    - dupl
+    - intrange
+
+severity:
+  default-severity: major
+
+issues:
+  fast: false
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  exclude-use-default: false
+  exclude-case-sensitive: true
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - errcheck
+        - errchkjson
+        - funlen
+        - gochecknoglobals
+        - goconst
+        - wrapcheck
+
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/kouprlabs)
+      - prefix(github.com/kouprlabs/voltaserve)
+
+  mnd:
+    ignored-numbers: ['2', '4', '8', '16', '32', '64', '10', '100', '1000']
+
+  gosec:
+    excludes:
+      - G104  # Errors unhandled. Already covered by errcheck linter.
+      - G307  # Deferring a method which returns an error. Already covered by errcheck linter.
+      - G601  # No longer applicable since go v1.22 update to for loops.
+
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment  # misalignment is accepted
+
+  revive:
+    # see https://github.com/mgechev/revive#recommended-configuration
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+
+  stylecheck:
+    checks: [all]
+
+  tagliatelle:
+    case:
+      rules:
+        json: goCamel
+        yaml: goSnake
+
+  varnamelen:
+    min-name-length: 1
+
+  wsl:
+    force-err-cuddling: true
+

--- a/mosaic/.golangci.yml
+++ b/mosaic/.golangci.yml
@@ -1,0 +1,122 @@
+---
+linters:
+  enable-all: true
+  disable:
+    - exhaustruct    # Structs may be uninitialized
+    - nlreturn       # covered by wsl cuddle rules
+    - nonamedreturns # named returns are acceptable
+    - depguard       # no dependency management
+    # deprecated
+    - execinquery
+    - gomnd
+    # To fix ###############################################
+    - wsl
+    - wrapcheck
+    - stylecheck
+    - perfsprint
+    - nilnil
+    - nilerr
+    - mnd
+    - intrange
+    - govet
+    - gochecknoglobals
+    - errchkjson
+    - err113
+    - unconvert
+    - revive
+    - errname
+    - cyclop
+    - prealloc
+    - lll
+    - gosec
+    - gofumpt
+    - godot
+    - gocritic
+    - gci
+    - funlen
+    - gocognit
+
+severity:
+  default-severity: major
+
+issues:
+  fast: false
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  exclude-use-default: false
+  exclude-case-sensitive: true
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - errcheck
+        - errchkjson
+        - funlen
+        - gochecknoglobals
+        - goconst
+        - wrapcheck
+
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/kouprlabs)
+      - prefix(github.com/kouprlabs/voltaserve)
+
+  mnd:
+    ignored-numbers: ['2', '4', '8', '16', '32', '64', '10', '100', '1000']
+
+  gosec:
+    excludes:
+      - G104  # Errors unhandled. Already covered by errcheck linter.
+      - G307  # Deferring a method which returns an error. Already covered by errcheck linter.
+      - G601  # No longer applicable since go v1.22 update to for loops.
+
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment  # misalignment is accepted
+
+  revive:
+    # see https://github.com/mgechev/revive#recommended-configuration
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+
+  stylecheck:
+    checks: [all]
+
+  tagliatelle:
+    case:
+      rules:
+        json: goCamel
+        yaml: goSnake
+
+  varnamelen:
+    min-name-length: 1
+
+  wsl:
+    force-err-cuddling: true
+

--- a/ui/.golangci.yml
+++ b/ui/.golangci.yml
@@ -1,0 +1,108 @@
+---
+linters:
+  enable-all: true
+  disable:
+    - exhaustruct    # Structs may be uninitialized
+    - nlreturn       # covered by wsl cuddle rules
+    - nonamedreturns # named returns are acceptable
+    - depguard       # no dependency management
+    # deprecated
+    - execinquery
+    - gomnd
+    # To fix ###############################################
+    - wsl
+    - wrapcheck
+    - gochecknoglobals
+    - stylecheck
+    - errorlint
+    - revive
+    - nestif
+    - gci
+    - funlen
+    - gocognit
+    - cyclop
+
+severity:
+  default-severity: major
+
+issues:
+  fast: false
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  exclude-use-default: false
+  exclude-case-sensitive: true
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - errcheck
+        - errchkjson
+        - funlen
+        - gochecknoglobals
+        - goconst
+        - wrapcheck
+
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/kouprlabs)
+      - prefix(github.com/kouprlabs/voltaserve)
+
+  mnd:
+    ignored-numbers: ['2', '4', '8', '16', '32', '64', '10', '100', '1000']
+
+  gosec:
+    excludes:
+      - G104  # Errors unhandled. Already covered by errcheck linter.
+      - G307  # Deferring a method which returns an error. Already covered by errcheck linter.
+      - G601  # No longer applicable since go v1.22 update to for loops.
+
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment  # misalignment is accepted
+
+  revive:
+    # see https://github.com/mgechev/revive#recommended-configuration
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+
+  stylecheck:
+    checks: [all]
+
+  tagliatelle:
+    case:
+      rules:
+        json: goCamel
+        yaml: goSnake
+
+  varnamelen:
+    min-name-length: 1
+
+  wsl:
+    force-err-cuddling: true
+


### PR DESCRIPTION
As go does have some pitfalls, it's recommended to enable linting on the code changes so we catch subtle bugs early, and to enforce a common code style.

This merge request does the initial work by adding a more explicit configuration for golangci-lint. All linters that fail are disabled, and we can enable them over the course of several MRs to get the code according to those standards