### PR TITLE
ci: removed run on pull request, refactor tagging

### DIFF
--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           name="voltaserve/api"
           version="${{ github.ref_name }}"
-          version="${version}#v"
+          version="${version#v}"
           IFS='.' read -r -a parts <<< "$version"
           TAGS="$name:$version"
 

--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -43,7 +43,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract tag that triggered this action
+      - name: Create tag list matching semver from executing tag
         if: ${{ github.ref_type == 'tag' }}
         run: |
           name="voltaserve/api"

--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -12,6 +12,12 @@ name: Build and Push voltaserve/api
 
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        required: false
+        default: ""
+        type: string
+        description: Override code checkout branch (e.g. "feature/branch")
   push:
     branches:
       - main
@@ -24,10 +30,14 @@ jobs:
   build_and_push:
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare input branch
+        if: ${{ github.event.inputs.branch != "" }}
+        run: echo "branch=refs/heads/${{ github.event.inputs.branch }}" >> $GITHUB_ENV
+
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ env.branch || github.ref }}
 
       - name: Set Up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -19,11 +19,6 @@ on:
       - "api/**"
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "api/**"
 
 jobs:
   build_and_push:
@@ -31,17 +26,13 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
 
       - name: Set Up QEMU
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64, amd64
-
-      - name: Extract tag that triggered this action
-        if: ${{ github.ref_type == 'tag' }}
-        run: |
-          TAG=${{ github.ref_name }}
-          echo "TRIMMED_TAG=${TAG#v}" >> $GITHUB_ENV
 
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -52,10 +43,20 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Extract tag that triggered this action
+        if: ${{ github.ref_type == 'tag' }}
+        run: |
+          TAG=${{ github.ref_name }}
+          echo "TAG=${TAG#v}" >> $GITHUB_ENV
+
+      - name: Set the tag on wokflow dispatch
+        if: ${{ github.ref_type != 'tag' }}
+        run: echo "TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
           context: ./api
           push: true
-          tags: voltaserve/api:${{ env.TRIMMED_TAG || 'latest' }}
+          tags: voltaserve/api:${{ env.TAG }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -46,17 +46,28 @@ jobs:
       - name: Extract tag that triggered this action
         if: ${{ github.ref_type == 'tag' }}
         run: |
-          TAG=${{ github.ref_name }}
-          echo "TAG=${TAG#v}" >> $GITHUB_ENV
+          name="voltaserve/api"
+          version="${{ github.ref_name }}"
+          version="${version}#v"
+          IFS='.' read -r -a parts <<< "$version"
+          TAGS="$name:$version"
+
+          for ((i=${#parts[@]}-1; i>0; i--)); do
+            tag=$(IFS='.'; echo "${parts[*]:0:$i}")
+            TAGS+=",$name:$tag"
+          done
+
+          TAGS+=",$name:latest"
+          echo "TAGS=$TAGS" >> $GITHUB_ENV
 
       - name: Set the tag on wokflow dispatch
         if: ${{ github.ref_type != 'tag' }}
-        run: echo "TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "TAGS=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
           context: ./api
           push: true
-          tags: voltaserve/api:${{ env.TAG }}
+          tags: ${{ env.TAGS }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-conversion.yml
+++ b/.github/workflows/build-conversion.yml
@@ -41,7 +41,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract tag that triggered this action
+      - name: Create tag list matching semver from executing tag
         if: ${{ github.ref_type == 'tag' }}
         run: |
           name="voltaserve/conversion"

--- a/.github/workflows/build-conversion.yml
+++ b/.github/workflows/build-conversion.yml
@@ -44,17 +44,28 @@ jobs:
       - name: Extract tag that triggered this action
         if: ${{ github.ref_type == 'tag' }}
         run: |
-          TAG=${{ github.ref_name }}
-          echo "TAG=${TAG#v}" >> $GITHUB_ENV
+          name="voltaserve/conversion"
+          version="${{ github.ref_name }}"
+          version="${version}#v"
+          IFS='.' read -r -a parts <<< "$version"
+          TAGS="$name:$version"
+
+          for ((i=${#parts[@]}-1; i>0; i--)); do
+            tag=$(IFS='.'; echo "${parts[*]:0:$i}")
+            TAGS+=",$name:$tag"
+          done
+
+          TAGS+=",$name:latest"
+          echo "TAGS=$TAGS" >> $GITHUB_ENV
 
       - name: Set the tag on wokflow dispatch
         if: ${{ github.ref_type != 'tag' }}
-        run: echo "TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "TAGS=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
           context: ./conversion
           push: true
-          tags: voltaserve/conversion:${{ env.TAG }}
+          tags: ${{ env.TAGS }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-conversion.yml
+++ b/.github/workflows/build-conversion.yml
@@ -19,11 +19,6 @@ on:
       - "conversion/**"
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "conversion/**"
 
 jobs:
   build_and_push:
@@ -37,12 +32,6 @@ jobs:
         with:
           platforms: arm64, amd64
 
-      - name: Extract tag that triggered this action
-        if: ${{ github.ref_type == 'tag' }}
-        run: |
-          TAG=${{ github.ref_name }}
-          echo "TRIMMED_TAG=${TAG#v}" >> $GITHUB_ENV
-
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -52,10 +41,20 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Extract tag that triggered this action
+        if: ${{ github.ref_type == 'tag' }}
+        run: |
+          TAG=${{ github.ref_name }}
+          echo "TAG=${TAG#v}" >> $GITHUB_ENV
+
+      - name: Set the tag on wokflow dispatch
+        if: ${{ github.ref_type != 'tag' }}
+        run: echo "TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
           context: ./conversion
           push: true
-          tags: voltaserve/conversion:${{ env.TRIMMED_TAG || 'latest' }}
+          tags: voltaserve/conversion:${{ env.TAG }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-conversion.yml
+++ b/.github/workflows/build-conversion.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           name="voltaserve/conversion"
           version="${{ github.ref_name }}"
-          version="${version}#v"
+          version="${version#v}"
           IFS='.' read -r -a parts <<< "$version"
           TAGS="$name:$version"
 

--- a/.github/workflows/build-conversion.yml
+++ b/.github/workflows/build-conversion.yml
@@ -12,6 +12,12 @@ name: Build and Push voltaserve/conversion
 
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        required: false
+        default: ""
+        type: string
+        description: Override code checkout branch (e.g. "feature/branch")
   push:
     branches:
       - main
@@ -24,8 +30,14 @@ jobs:
   build_and_push:
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare input branch
+        if: ${{ github.event.inputs.branch != "" }}
+        run: echo "branch=refs/heads/${{ github.event.inputs.branch }}" >> $GITHUB_ENV
+
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.branch || github.ref }}
 
       - name: Set Up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-idp.yml
+++ b/.github/workflows/build-idp.yml
@@ -41,7 +41,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract tag that triggered this action
+      - name: Create tag list matching semver from executing tag
         if: ${{ github.ref_type == 'tag' }}
         run: |
           name="voltaserve/idp"

--- a/.github/workflows/build-idp.yml
+++ b/.github/workflows/build-idp.yml
@@ -19,11 +19,6 @@ on:
       - "idp/**"
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "idp/**"
 
 jobs:
   build_and_push:
@@ -37,12 +32,6 @@ jobs:
         with:
           platforms: arm64, amd64
 
-      - name: Extract tag that triggered this action
-        if: ${{ github.ref_type == 'tag' }}
-        run: |
-          TAG=${{ github.ref_name }}
-          echo "TRIMMED_TAG=${TAG#v}" >> $GITHUB_ENV
-
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -52,10 +41,20 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Extract tag that triggered this action
+        if: ${{ github.ref_type == 'tag' }}
+        run: |
+          TAG=${{ github.ref_name }}
+          echo "TAG=${TAG#v}" >> $GITHUB_ENV
+
+      - name: Set the tag on wokflow dispatch
+        if: ${{ github.ref_type != 'tag' }}
+        run: echo "TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
           context: ./idp
           push: true
-          tags: voltaserve/idp:${{ env.TRIMMED_TAG || 'latest' }}
+          tags: voltaserve/idp:${{ env.TAG }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-idp.yml
+++ b/.github/workflows/build-idp.yml
@@ -44,17 +44,28 @@ jobs:
       - name: Extract tag that triggered this action
         if: ${{ github.ref_type == 'tag' }}
         run: |
-          TAG=${{ github.ref_name }}
-          echo "TAG=${TAG#v}" >> $GITHUB_ENV
+          name="voltaserve/idp"
+          version="${{ github.ref_name }}"
+          version="${version}#v"
+          IFS='.' read -r -a parts <<< "$version"
+          TAGS="$name:$version"
+
+          for ((i=${#parts[@]}-1; i>0; i--)); do
+            tag=$(IFS='.'; echo "${parts[*]:0:$i}")
+            TAGS+=",$name:$tag"
+          done
+
+          TAGS+=",$name:latest"
+          echo "TAGS=$TAGS" >> $GITHUB_ENV
 
       - name: Set the tag on wokflow dispatch
         if: ${{ github.ref_type != 'tag' }}
-        run: echo "TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "TAGS=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
           context: ./idp
           push: true
-          tags: voltaserve/idp:${{ env.TAG }}
+          tags: ${{ env.TAGS }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-idp.yml
+++ b/.github/workflows/build-idp.yml
@@ -12,6 +12,12 @@ name: Build and Push voltaserve/idp
 
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        required: false
+        default: ""
+        type: string
+        description: Override code checkout branch (e.g. "feature/branch")
   push:
     branches:
       - main
@@ -24,8 +30,14 @@ jobs:
   build_and_push:
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare input branch
+        if: ${{ github.event.inputs.branch != "" }}
+        run: echo "branch=refs/heads/${{ github.event.inputs.branch }}" >> $GITHUB_ENV
+
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.branch || github.ref }}
 
       - name: Set Up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-idp.yml
+++ b/.github/workflows/build-idp.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           name="voltaserve/idp"
           version="${{ github.ref_name }}"
-          version="${version}#v"
+          version="${version#v}"
           IFS='.' read -r -a parts <<< "$version"
           TAGS="$name:$version"
 

--- a/.github/workflows/build-language.yml
+++ b/.github/workflows/build-language.yml
@@ -46,7 +46,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract tag that triggered this action
+      - name: Create tag list matching semver from executing tag
         if: ${{ github.ref_type == 'tag' }}
         run: |
           name="voltaserve/language"

--- a/.github/workflows/build-language.yml
+++ b/.github/workflows/build-language.yml
@@ -12,6 +12,12 @@ name: Build and Push voltaserve/language
 
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        required: false
+        default: ""
+        type: string
+        description: Override code checkout branch (e.g. "feature/branch")
   push:
     branches:
       - main
@@ -29,8 +35,14 @@ jobs:
   build_and_push:
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare input branch
+        if: ${{ github.event.inputs.branch != "" }}
+        run: echo "branch=refs/heads/${{ github.event.inputs.branch }}" >> $GITHUB_ENV
+
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.branch || github.ref }}
 
       - name: Set Up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-language.yml
+++ b/.github/workflows/build-language.yml
@@ -37,12 +37,6 @@ jobs:
         with:
           platforms: arm64, amd64
 
-      - name: Extract tag that triggered this action
-        if: ${{ github.ref_type == 'tag' }}
-        run: |
-          TAG=${{ github.ref_name }}
-          echo "TRIMMED_TAG=${TAG#v}" >> $GITHUB_ENV
-
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -52,10 +46,20 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Extract tag that triggered this action
+        if: ${{ github.ref_type == 'tag' }}
+        run: |
+          TAG=${{ github.ref_name }}
+          echo "TAG=${TAG#v}" >> $GITHUB_ENV
+
+      - name: Set the tag on wokflow dispatch
+        if: ${{ github.ref_type != 'tag' }}
+        run: echo "TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
           context: ./language
           push: true
-          tags: voltaserve/language:${{ env.TRIMMED_TAG || 'latest' }}
+          tags: voltaserve/language:${{ env.TAG }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-language.yml
+++ b/.github/workflows/build-language.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           name="voltaserve/language"
           version="${{ github.ref_name }}"
-          version="${version}#v"
+          version="${version#v}"
           IFS='.' read -r -a parts <<< "$version"
           TAGS="$name:$version"
 

--- a/.github/workflows/build-language.yml
+++ b/.github/workflows/build-language.yml
@@ -49,17 +49,28 @@ jobs:
       - name: Extract tag that triggered this action
         if: ${{ github.ref_type == 'tag' }}
         run: |
-          TAG=${{ github.ref_name }}
-          echo "TAG=${TAG#v}" >> $GITHUB_ENV
+          name="voltaserve/language"
+          version="${{ github.ref_name }}"
+          version="${version}#v"
+          IFS='.' read -r -a parts <<< "$version"
+          TAGS="$name:$version"
+
+          for ((i=${#parts[@]}-1; i>0; i--)); do
+            tag=$(IFS='.'; echo "${parts[*]:0:$i}")
+            TAGS+=",$name:$tag"
+          done
+
+          TAGS+=",$name:latest"
+          echo "TAGS=$TAGS" >> $GITHUB_ENV
 
       - name: Set the tag on wokflow dispatch
         if: ${{ github.ref_type != 'tag' }}
-        run: echo "TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "TAGS=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
           context: ./language
           push: true
-          tags: voltaserve/language:${{ env.TAG }}
+          tags: ${{ env.TAGS }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-mosaic.yml
+++ b/.github/workflows/build-mosaic.yml
@@ -19,11 +19,6 @@ on:
       - "mosaic/**"
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "mosaic/**"
 
 jobs:
   build_and_push:
@@ -37,12 +32,6 @@ jobs:
         with:
           platforms: arm64, amd64
 
-      - name: Extract tag that triggered this action
-        if: ${{ github.ref_type == 'tag' }}
-        run: |
-          TAG=${{ github.ref_name }}
-          echo "TRIMMED_TAG=${TAG#v}" >> $GITHUB_ENV
-
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -52,10 +41,20 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Extract tag that triggered this action
+        if: ${{ github.ref_type == 'tag' }}
+        run: |
+          TAG=${{ github.ref_name }}
+          echo "TAG=${TAG#v}" >> $GITHUB_ENV
+
+      - name: Set the tag on wokflow dispatch
+        if: ${{ github.ref_type != 'tag' }}
+        run: echo "TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
           context: ./mosaic
           push: true
-          tags: voltaserve/mosaic:${{ env.TRIMMED_TAG || 'latest' }}
+          tags: voltaserve/mosaic:${{ env.TAG }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-mosaic.yml
+++ b/.github/workflows/build-mosaic.yml
@@ -12,6 +12,12 @@ name: Build and Push voltaserve/mosaic
 
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        required: false
+        default: ""
+        type: string
+        description: Override code checkout branch (e.g. "feature/branch")
   push:
     branches:
       - main
@@ -24,8 +30,14 @@ jobs:
   build_and_push:
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare input branch
+        if: ${{ github.event.inputs.branch != "" }}
+        run: echo "branch=refs/heads/${{ github.event.inputs.branch }}" >> $GITHUB_ENV
+
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.branch || github.ref }}
 
       - name: Set Up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-mosaic.yml
+++ b/.github/workflows/build-mosaic.yml
@@ -41,7 +41,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract tag that triggered this action
+      - name: Create tag list matching semver from executing tag
         if: ${{ github.ref_type == 'tag' }}
         run: |
           name="voltaserve/mosaic"

--- a/.github/workflows/build-mosaic.yml
+++ b/.github/workflows/build-mosaic.yml
@@ -44,17 +44,28 @@ jobs:
       - name: Extract tag that triggered this action
         if: ${{ github.ref_type == 'tag' }}
         run: |
-          TAG=${{ github.ref_name }}
-          echo "TAG=${TAG#v}" >> $GITHUB_ENV
+          name="voltaserve/mosaic"
+          version="${{ github.ref_name }}"
+          version="${version}#v"
+          IFS='.' read -r -a parts <<< "$version"
+          TAGS="$name:$version"
+
+          for ((i=${#parts[@]}-1; i>0; i--)); do
+            tag=$(IFS='.'; echo "${parts[*]:0:$i}")
+            TAGS+=",$name:$tag"
+          done
+
+          TAGS+=",$name:latest"
+          echo "TAGS=$TAGS" >> $GITHUB_ENV
 
       - name: Set the tag on wokflow dispatch
         if: ${{ github.ref_type != 'tag' }}
-        run: echo "TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "TAGS=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
           context: ./mosaic
           push: true
-          tags: voltaserve/mosaic:${{ env.TAG }}
+          tags: ${{ env.TAGS }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-mosaic.yml
+++ b/.github/workflows/build-mosaic.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           name="voltaserve/mosaic"
           version="${{ github.ref_name }}"
-          version="${version}#v"
+          version="${version#v}"
           IFS='.' read -r -a parts <<< "$version"
           TAGS="$name:$version"
 

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -19,11 +19,6 @@ on:
       - "ui/**"
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "ui/**"
 
 jobs:
   build_and_push:
@@ -37,12 +32,6 @@ jobs:
         with:
           platforms: arm64, amd64
 
-      - name: Extract tag that triggered this action
-        if: ${{ github.ref_type == 'tag' }}
-        run: |
-          TAG=${{ github.ref_name }}
-          echo "TRIMMED_TAG=${TAG#v}" >> $GITHUB_ENV
-
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -52,10 +41,20 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Extract tag that triggered this action
+        if: ${{ github.ref_type == 'tag' }}
+        run: |
+          TAG=${{ github.ref_name }}
+          echo "TAG=${TAG#v}" >> $GITHUB_ENV
+
+      - name: Set the tag on wokflow dispatch
+        if: ${{ github.ref_type != 'tag' }}
+        run: echo "TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
           context: ./ui
           push: true
-          tags: voltaserve/ui:${{ env.TRIMMED_TAG || 'latest' }}
+          tags: voltaserve/ui:${{ env.TAG }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -44,17 +44,28 @@ jobs:
       - name: Extract tag that triggered this action
         if: ${{ github.ref_type == 'tag' }}
         run: |
-          TAG=${{ github.ref_name }}
-          echo "TAG=${TAG#v}" >> $GITHUB_ENV
+          name="voltaserve/ui"
+          version="${{ github.ref_name }}"
+          version="${version}#v"
+          IFS='.' read -r -a parts <<< "$version"
+          TAGS="$name:$version"
+
+          for ((i=${#parts[@]}-1; i>0; i--)); do
+            tag=$(IFS='.'; echo "${parts[*]:0:$i}")
+            TAGS+=",$name:$tag"
+          done
+
+          TAGS+=",$name:latest"
+          echo "TAGS=$TAGS" >> $GITHUB_ENV
 
       - name: Set the tag on wokflow dispatch
         if: ${{ github.ref_type != 'tag' }}
-        run: echo "TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "TAGS=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
           context: ./ui
           push: true
-          tags: voltaserve/ui:${{ env.TAG }}
+          tags: ${{ env.TAGS }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -41,7 +41,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract tag that triggered this action
+      - name: Create tag list matching semver from executing tag
         if: ${{ github.ref_type == 'tag' }}
         run: |
           name="voltaserve/ui"

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -12,6 +12,12 @@ name: Build and Push voltaserve/ui
 
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        required: false
+        default: ""
+        type: string
+        description: Override code checkout branch (e.g. "feature/branch")
   push:
     branches:
       - main
@@ -24,8 +30,14 @@ jobs:
   build_and_push:
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare input branch
+        if: ${{ github.event.inputs.branch != "" }}
+        run: echo "branch=refs/heads/${{ github.event.inputs.branch }}" >> $GITHUB_ENV
+
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.branch || github.ref }}
 
       - name: Set Up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           name="voltaserve/ui"
           version="${{ github.ref_name }}"
-          version="${version}#v"
+          version="${version#v}"
           IFS='.' read -r -a parts <<< "$version"
           TAGS="$name:$version"
 

--- a/.github/workflows/build-webdav.yml
+++ b/.github/workflows/build-webdav.yml
@@ -41,7 +41,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract tag that triggered this action
+      - name: Create tag list matching semver from executing tag
         if: ${{ github.ref_type == 'tag' }}
         run: |
           name="voltaserve/webdav"

--- a/.github/workflows/build-webdav.yml
+++ b/.github/workflows/build-webdav.yml
@@ -12,6 +12,12 @@ name: Build and Push voltaserve/webdav
 
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        required: false
+        default: ""
+        type: string
+        description: Override code checkout branch (e.g. "feature/branch")
   push:
     branches:
       - main
@@ -24,8 +30,14 @@ jobs:
   build_and_push:
     runs-on: ubuntu-latest
     steps:
+      - name: Prepare input branch
+        if: ${{ github.event.inputs.branch != "" }}
+        run: echo "branch=refs/heads/${{ github.event.inputs.branch }}" >> $GITHUB_ENV
+
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.branch || github.ref }}
 
       - name: Set Up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-webdav.yml
+++ b/.github/workflows/build-webdav.yml
@@ -44,17 +44,28 @@ jobs:
       - name: Extract tag that triggered this action
         if: ${{ github.ref_type == 'tag' }}
         run: |
-          TAG=${{ github.ref_name }}
-          echo "TAG=${TAG#v}" >> $GITHUB_ENV
+          name="voltaserve/webdav"
+          version="${{ github.ref_name }}"
+          version="${version}#v"
+          IFS='.' read -r -a parts <<< "$version"
+          TAGS="$name:$version"
+
+          for ((i=${#parts[@]}-1; i>0; i--)); do
+            tag=$(IFS='.'; echo "${parts[*]:0:$i}")
+            TAGS+=",$name:$tag"
+          done
+
+          TAGS+=",$name:latest"
+          echo "TAGS=$TAGS" >> $GITHUB_ENV
 
       - name: Set the tag on wokflow dispatch
         if: ${{ github.ref_type != 'tag' }}
-        run: echo "TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "TAGS=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
           context: ./webdav
           push: true
-          tags: voltaserve/webdav:${{ env.TAG }}
+          tags: ${{ env.TAGS }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-webdav.yml
+++ b/.github/workflows/build-webdav.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           name="voltaserve/webdav"
           version="${{ github.ref_name }}"
-          version="${version}#v"
+          version="${version#v}"
           IFS='.' read -r -a parts <<< "$version"
           TAGS="$name:$version"
 

--- a/.github/workflows/build-webdav.yml
+++ b/.github/workflows/build-webdav.yml
@@ -19,11 +19,6 @@ on:
       - "webdav/**"
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "webdav/**"
 
 jobs:
   build_and_push:
@@ -37,12 +32,6 @@ jobs:
         with:
           platforms: arm64, amd64
 
-      - name: Extract tag that triggered this action
-        if: ${{ github.ref_type == 'tag' }}
-        run: |
-          TAG=${{ github.ref_name }}
-          echo "TRIMMED_TAG=${TAG#v}" >> $GITHUB_ENV
-
       - name: Set Up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -52,10 +41,20 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Extract tag that triggered this action
+        if: ${{ github.ref_type == 'tag' }}
+        run: |
+          TAG=${{ github.ref_name }}
+          echo "TAG=${TAG#v}" >> $GITHUB_ENV
+
+      - name: Set the tag on wokflow dispatch
+        if: ${{ github.ref_type != 'tag' }}
+        run: echo "TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       - name: Build and Push Docker Image
         uses: docker/build-push-action@v5
         with:
           context: ./webdav
           push: true
-          tags: voltaserve/webdav:${{ env.TRIMMED_TAG || 'latest' }}
+          tags: voltaserve/webdav:${{ env.TAG }}
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Updated pipelines that are triggered only manually or on push. Updated tagging to either short commit sha or release/tag version.

Built image:
https://hub.docker.com/layers/voltaserve/api/47e4c20/images/sha256-91e93cd7aa83a2f63cae68a0721b1cad27e112b26f384499de124c6cd9c96cb9?context=explore

Closes: #142 