### PR TITLE
fix: 3D thumbnail generation

### DIFF
--- a/conversion/Dockerfile
+++ b/conversion/Dockerfile
@@ -586,30 +586,6 @@ RUN apt-get install -y \
 
 RUN apt-get install -y \
   tesseract-ocr \
-  tesseract-ocr-data-osd \
-  tesseract-ocr-data-ara \
-  tesseract-ocr-data-chi_sim \
-  tesseract-ocr-data-chi_tra \
-  tesseract-ocr-data-eng \
-  tesseract-ocr-data-fra \
-  tesseract-ocr-data-deu \
-  tesseract-ocr-data-por \
-  tesseract-ocr-data-spa
-
-RUN apt-get install -y \
-  tesseract-ocr \
-  tesseract-ocr-osd \
-  tesseract-ocr-ara \
-  tesseract-ocr-chi-sim \
-  tesseract-ocr-chi-tra \
-  tesseract-ocr-eng \
-  tesseract-ocr-fra \
-  tesseract-ocr-deu \
-  tesseract-ocr-por \
-  tesseract-ocr-spa
-
-RUN apt-get install -y \
-  tesseract-ocr \
   tesseract-ocr-osd \
   tesseract-ocr-ara \
   tesseract-ocr-chi-sim \

--- a/conversion/Dockerfile
+++ b/conversion/Dockerfile
@@ -36,6 +36,8 @@ RUN apt-get install -y \
 
 RUN npm i -g gltf-pipeline
 RUN npm i -g @koupr/screenshot-glb
+RUN npx playwright install
+RUN npx playwright install-deps
 
 RUN apt-get install -y \
   libreoffice-core-nogui \

--- a/conversion/Dockerfile
+++ b/conversion/Dockerfile
@@ -46,131 +46,6 @@ RUN apt-get install -y \
   libreoffice-math-nogui
 
 RUN apt-get install -y \
-  fonts-arphic-ukai \
-  fonts-arphic-uming \
-  fonts-beng \
-  fonts-beng-extra \
-  fonts-dejavu-core \
-  fonts-dejavu-extra \
-  fonts-deva \
-  fonts-deva-extra \
-  fonts-droid-fallback \
-  fonts-farsiweb \
-  fonts-font-awesome \
-  fonts-freefont-ttf \
-  fonts-gargi \
-  fonts-gubbi \
-  fonts-gujr \
-  fonts-gujr-extra \
-  fonts-guru \
-  fonts-guru-extra \
-  fonts-hosny-amiri \
-  fonts-indic \
-  fonts-kacst \
-  fonts-kacst-one \
-  fonts-kalapi \
-  fonts-khmeros \
-  fonts-khmeros-core \
-  fonts-knda \
-  fonts-lao \
-  fonts-lato \
-  fonts-liberation \
-  fonts-liberation2 \
-  fonts-lklug-sinhala
-
-RUN apt-get install -y \
-  fonts-lohit-beng-assamese \
-  fonts-lohit-beng-bengali \
-  fonts-lohit-deva \
-  fonts-lohit-gujr \
-  fonts-lohit-guru \
-  fonts-lohit-knda \
-  fonts-lohit-mlym \
-  fonts-lohit-orya \
-  fonts-lohit-taml \
-  fonts-lohit-taml-classical \
-  fonts-lohit-telu \
-  fonts-manchufont \
-  fonts-mathjax \
-  fonts-mlym \
-  fonts-nafees \
-  fonts-nakula \
-  fonts-navilu \
-  fonts-noto-cjk \
-  fonts-noto-cjk-extra \
-  fonts-noto-color-emoji \
-  fonts-noto-core \
-  fonts-noto-mono \
-  fonts-noto-ui-core \
-  fonts-opensymbol \
-  fonts-orya \
-  fonts-orya-extra \
-  fonts-pagul \
-  fonts-sahadeva \
-  fonts-samyak-deva \
-  fonts-samyak-gujr \
-  fonts-samyak-mlym \
-  fonts-samyak-taml \
-  fonts-sarai \
-  fonts-sil-abyssinica \
-  fonts-sil-ezra \
-  fonts-sil-nuosusil \
-  fonts-sil-padauk \
-  fonts-sil-scheherazade \
-  fonts-smc
-
-RUN apt-get install -y \
-  fonts-smc-anjalioldlipi \
-  fonts-smc-chilanka \
-  fonts-smc-dyuthi \
-  fonts-smc-gayathri \
-  fonts-smc-karumbi \
-  fonts-smc-keraleeyam \
-  fonts-smc-manjari \
-  fonts-smc-meera \
-  fonts-smc-rachana \
-  fonts-smc-raghumalayalamsans \
-  fonts-smc-suruma \
-  fonts-smc-uroob \
-  fonts-taml \
-  fonts-telu \
-  fonts-telu-extra \
-  fonts-teluguvijayam \
-  fonts-thai-tlwg \
-  fonts-tibetan-machine \
-  fonts-tlwg-garuda \
-  fonts-tlwg-garuda-ttf \
-  fonts-tlwg-kinnari \
-  fonts-tlwg-kinnari-ttf \
-  fonts-tlwg-laksaman \
-  fonts-tlwg-laksaman-ttf \
-  fonts-tlwg-loma \
-  fonts-tlwg-loma-ttf
-
-RUN apt-get install -y \
-  fonts-tlwg-mono \
-  fonts-tlwg-mono-ttf \
-  fonts-tlwg-norasi \
-  fonts-tlwg-norasi-ttf \
-  fonts-tlwg-purisa \
-  fonts-tlwg-purisa-ttf \
-  fonts-tlwg-sawasdee \
-  fonts-tlwg-sawasdee-ttf \
-  fonts-tlwg-typewriter \
-  fonts-tlwg-typewriter-ttf \
-  fonts-tlwg-typist \
-  fonts-tlwg-typist-ttf \
-  fonts-tlwg-typo \
-  fonts-tlwg-typo-ttf \
-  fonts-tlwg-umpush \
-  fonts-tlwg-umpush-ttf \
-  fonts-tlwg-waree \
-  fonts-tlwg-waree-ttf \
-  fonts-ubuntu \
-  fonts-ubuntu-console \
-  fonts-ukij-uyghur \
-  fonts-urw-base35 \
-  fonts-yrsa-rasa \
   fonts-3270 \
   fonts-adf-accanthis \
   fonts-adf-baskervald \
@@ -181,9 +56,7 @@ RUN apt-get install -y \
   fonts-adf-libris \
   fonts-adf-mekanus \
   fonts-adf-oldania \
-  fonts-adf-romande
-
-RUN apt-get install -y \
+  fonts-adf-romande \
   fonts-adf-solothurn \
   fonts-adf-switzera \
   fonts-adf-tribun \
@@ -208,8 +81,14 @@ RUN apt-get install -y \
   fonts-arphic-bsmi00lp \
   fonts-arphic-gbsn00lp \
   fonts-arphic-gkai00mp \
+  fonts-arphic-ukai \
+  fonts-arphic-uming \
   fonts-arundina \
   fonts-atarismall \
+  fonts-atarist \
+  fonts-atkinson-hyperlegible \
+  fonts-atkinson-hyperlegible-ttf \
+  fonts-atkinson-hyperlegible-web \
   fonts-averia-gwf \
   fonts-averia-sans-gwf \
   fonts-averia-serif-gwf \
@@ -219,6 +98,8 @@ RUN apt-get install -y \
   fonts-baekmuk \
   fonts-bajaderka \
   fonts-bebas-neue \
+  fonts-beng \
+  fonts-beng-extra \
   fonts-beteckna \
   fonts-blankenburg \
   fonts-bpg-georgian \
@@ -232,12 +113,13 @@ RUN apt-get install -y \
   fonts-cascadia-code \
   fonts-cegui \
   fonts-century-catalogue \
-  fonts-cherrybomb
-
-RUN apt-get install -y \
+  fonts-cherrybomb \
+  fonts-chomsky \
   fonts-circos-symbols \
   fonts-clear-sans \
   fonts-cmu \
+  fonts-cns11643-kai \
+  fonts-cns11643-sung \
   fonts-comfortaa \
   fonts-comic-neue \
   fonts-compagnon \
@@ -255,11 +137,19 @@ RUN apt-get install -y \
   fonts-dancingscript \
   fonts-ddc-uchen \
   fonts-dejavu \
+  fonts-dejavu-core \
+  fonts-dejavu-extra \
+  fonts-dejavu-mono \
+  fonts-dejavu-web \
   fonts-dejima-mincho \
   fonts-denemo \
+  fonts-deva \
+  fonts-deva-extra \
   fonts-dkg-handwriting \
+  fonts-dm-mono \
   fonts-dosis \
   fonts-dotgothic16 \
+  fonts-droid-fallback \
   fonts-dseg \
   fonts-dustin \
   fonts-dzongkha \
@@ -277,18 +167,20 @@ RUN apt-get install -y \
   fonts-eurofurence \
   fonts-evertype-conakry \
   fonts-f500 \
-  fonts-fantasma
-
-RUN apt-get install -y \
+  fonts-fantasma \
   fonts-fantasque-sans \
   fonts-fanwood \
+  fonts-farsiweb \
   fonts-femkeklaver \
   fonts-ferrite-core \
   fonts-firacode \
+  fonts-font-awesome \
   fonts-fork-awesome \
   fonts-freefarsi \
   fonts-freefont-otf \
+  fonts-freefont-ttf \
   fonts-gamaliel \
+  fonts-gargi \
   fonts-gemunu-libre \
   fonts-georgewilliams \
   fonts-gfs-artemisia \
@@ -309,6 +201,11 @@ RUN apt-get install -y \
   fonts-go \
   fonts-gotico-antiqua \
   fonts-goudybookletter \
+  fonts-gubbi \
+  fonts-gujr \
+  fonts-gujr-extra \
+  fonts-guru \
+  fonts-guru-extra \
   fonts-hack \
   fonts-hack-otf \
   fonts-hack-ttf \
@@ -317,11 +214,12 @@ RUN apt-get install -y \
   fonts-havana \
   fonts-hermit \
   fonts-horai-umefont \
+  fonts-hosny-amiri \
   fonts-hosny-thabit \
-  fonts-humor-sans
-
-RUN apt-get install -y \
+  fonts-humor-sans \
+  fonts-ibm-plex \
   fonts-inconsolata \
+  fonts-indic \
   fonts-inter \
   fonts-inter-variable \
   fonts-ipaexfont \
@@ -330,26 +228,44 @@ RUN apt-get install -y \
   fonts-ipafont \
   fonts-ipafont-gothic \
   fonts-ipafont-mincho \
+  fonts-ipafont-nonfree-jisx0208 \
+  fonts-ipafont-nonfree-uigothic \
   fonts-ipamj-mincho \
+  fonts-ir \
+  fonts-irannastaliq \
   fonts-isabella \
+  fonts-jetbrains-mono \
+  fonts-jetbrains-mono-web \
   fonts-johnsmith-induni \
   fonts-joscelyn \
   fonts-jsmath \
   fonts-junction \
   fonts-junicode \
   fonts-jura \
+  fonts-kacst \
+  fonts-kacst-one \
+  fonts-kalapi \
   fonts-kanjistrokeorders \
   fonts-karla \
   fonts-karmilla \
   fonts-katex \
   fonts-kaushanscript \
+  fonts-khmeros \
+  fonts-khmeros-core \
   fonts-kiloji \
   fonts-klaudia-berenika \
   fonts-klee \
+  fonts-knda \
+  fonts-kode-mono \
   fonts-komatuna \
   fonts-konatu \
   fonts-kouzan-mouhitsu \
   fonts-kristi \
+  fonts-lao \
+  fonts-larabie-deco \
+  fonts-larabie-straight \
+  fonts-larabie-uncommon \
+  fonts-lato \
   fonts-ldco \
   fonts-le-murmure \
   fonts-league-mono \
@@ -361,28 +277,49 @@ RUN apt-get install -y \
   fonts-lexi-gulim \
   fonts-lexi-saebom \
   fonts-lg-aboriginal \
+  fonts-liberation \
+  fonts-liberation-sans-narrow \
+  fonts-liberation2 \
   fonts-libfinal \
   fonts-lindenhill \
   fonts-linex \
   fonts-linuxlibertine \
+  fonts-lklug-sinhala \
   fonts-lmodern \
   fonts-lobster \
   fonts-lobstertwo \
+  fonts-lohit-beng-assamese \
+  fonts-lohit-beng-bengali \
+  fonts-lohit-deva \
   fonts-lohit-deva-marathi \
   fonts-lohit-deva-nepali \
+  fonts-lohit-gujr \
+  fonts-lohit-guru \
+  fonts-lohit-knda \
+  fonts-lohit-mlym \
+  fonts-lohit-orya \
+  fonts-lohit-taml \
+  fonts-lohit-taml-classical \
+  fonts-lohit-telu \
+  fonts-lxgw-wenkai \
+  fonts-lxgw-wenkai-doc \
   fonts-lyx \
+  fonts-manchufont \
   fonts-manrope \
   fonts-material-design-icons-iconfont \
   fonts-materialdesignicons-webfont \
-  fonts-mathjax-extras
-
-RUN apt-get install -y \
+  fonts-mathjax \
+  fonts-mathjax-extras \
   fonts-meera-inimai \
   fonts-meera-taml \
   fonts-migmix \
+  fonts-mikachan \
   fonts-millimetre \
   fonts-misaki \
+  fonts-mlym \
   fonts-mmcedar \
+  fonts-moe-standard-kai \
+  fonts-moe-standard-song \
   fonts-mona \
   fonts-monapo \
   fonts-monlam \
@@ -392,20 +329,33 @@ RUN apt-get install -y \
   fonts-monoid-halftight \
   fonts-monoid-loose \
   fonts-monoid-tight \
+  fonts-mononoki \
+  fonts-montserrat \
+  fonts-morisawa-bizud-gothic \
+  fonts-morisawa-bizud-mincho \
   fonts-motoya-l-cedar \
   fonts-motoya-l-maruberi \
   fonts-mph-2b-damase \
   fonts-mplus \
   fonts-myanmar \
+  fonts-nafees \
+  fonts-nakula \
   fonts-nanum \
   fonts-nanum-coding \
   fonts-nanum-eco \
   fonts-nanum-extra \
   fonts-national-park \
   fonts-naver-d2coding \
+  fonts-navilu \
   fonts-noto \
+  fonts-noto-cjk \
+  fonts-noto-cjk-extra \
+  fonts-noto-color-emoji \
+  fonts-noto-core \
   fonts-noto-extra \
   fonts-noto-hinted \
+  fonts-noto-mono \
+  fonts-noto-ui-core \
   fonts-noto-ui-extra \
   fonts-noto-unhinted \
   fonts-ocr-a \
@@ -418,17 +368,18 @@ RUN apt-get install -y \
   fonts-open-sans \
   fonts-opendin \
   fonts-opendyslexic \
+  fonts-opensymbol \
   fonts-oradano-mincho-gsrr \
+  fonts-orya \
+  fonts-orya-extra \
   fonts-osifont \
   fonts-oxygen \
+  fonts-pagul \
   fonts-paktype \
   fonts-paratype \
   fonts-pc \
   fonts-pc-extra \
-  fonts-pecita \
-  fonts-play
-
-RUN apt-get install -y \
+  fonts-play \
   fonts-povray \
   fonts-powerline \
   fonts-prociono \
@@ -448,15 +399,25 @@ RUN apt-get install -y \
   fonts-roboto-slab \
   fonts-roboto-unhinted \
   fonts-rocknroll \
+  fonts-routed-gothic \
   fonts-rufscript \
+  fonts-sahadeva \
+  fonts-sahel \
+  fonts-sahel-variable \
   fonts-sambhota-tsugring \
   fonts-sambhota-yigchung \
   fonts-samyak \
+  fonts-samyak-deva \
+  fonts-samyak-gujr \
+  fonts-samyak-mlym \
   fonts-samyak-orya \
+  fonts-samyak-taml \
+  fonts-sarai \
   fonts-sawarabi-gothic \
   fonts-sawarabi-mincho \
   fonts-senamirmir-washra \
   fonts-seto \
+  fonts-sil-abyssinica \
   fonts-sil-akatab \
   fonts-sil-alkalami \
   fonts-sil-andika \
@@ -469,6 +430,7 @@ RUN apt-get install -y \
   fonts-sil-dai-banna \
   fonts-sil-doulos \
   fonts-sil-doulos-compact \
+  fonts-sil-ezra \
   fonts-sil-galatia \
   fonts-sil-gentium \
   fonts-sil-gentium-basic \
@@ -479,10 +441,11 @@ RUN apt-get install -y \
   fonts-sil-mingzat \
   fonts-sil-mondulkiri \
   fonts-sil-mondulkiri-extra \
+  fonts-sil-nuosusil \
+  fonts-sil-padauk \
+  fonts-sil-scheherazade \
   fonts-sil-shimenkan \
-  fonts-sil-shimenkan-gsm
-
-RUN apt-get install -y \
+  fonts-sil-shimenkan-gsm \
   fonts-sil-shimenkan-guifan \
   fonts-sil-shimenkan-mas \
   fonts-sil-shimenkan-mgs \
@@ -494,88 +457,131 @@ RUN apt-get install -y \
   fonts-sil-tagmukay \
   fonts-sil-taiheritagepro \
   fonts-sil-zaghawa-beria \
-  fonts-sipa-arundina \
   fonts-sixtyfour \
   fonts-sjfonts \
+  fonts-smc \
+  fonts-smc-anjalioldlipi \
+  fonts-smc-chilanka \
+  fonts-smc-dyuthi \
+  fonts-smc-gayathri \
+  fonts-smc-karumbi \
+  fonts-smc-keraleeyam \
+  fonts-smc-manjari \
+  fonts-smc-meera \
+  fonts-smc-rachana \
+  fonts-smc-raghumalayalamsans \
+  fonts-smc-suruma \
+  fonts-smc-uroob \
+  fonts-smiley-sans \
   fonts-solide-mirage \
   fonts-sora \
+  fonts-space-grotesk \
+  fonts-space-grotesk-otf \
+  fonts-space-grotesk-ttf \
   fonts-spleen \
   fonts-staypuft \
   fonts-stick \
   fonts-stix \
   fonts-summersby \
   fonts-symbola \
+  fonts-tagbanwa \
   fonts-takao \
   fonts-takao-gothic \
   fonts-takao-mincho \
   fonts-takao-pgothic \
+  fonts-taml \
   fonts-taml-tamu \
   fonts-taml-tscu \
+  fonts-telu \
+  fonts-telu-extra \
+  fonts-teluguvijayam \
   fonts-terminus \
   fonts-terminus-otb \
   fonts-texgyre \
+  fonts-texgyre-math \
+  fonts-thai-tlwg \
   fonts-thai-tlwg-otf \
   fonts-thai-tlwg-ttf \
   fonts-thai-tlwg-web \
+  fonts-tibetan-machine \
   fonts-tiresias \
+  fonts-tlwg-garuda \
   fonts-tlwg-garuda-otf \
+  fonts-tlwg-garuda-ttf \
+  fonts-tlwg-kinnari \
   fonts-tlwg-kinnari-otf \
+  fonts-tlwg-kinnari-ttf \
+  fonts-tlwg-laksaman \
   fonts-tlwg-laksaman-otf \
-  fonts-tlwg-loma-otf
-
-RUN apt-get install -y \
+  fonts-tlwg-laksaman-ttf \
+  fonts-tlwg-loma \
+  fonts-tlwg-loma-otf \
+  fonts-tlwg-loma-ttf \
+  fonts-tlwg-mono \
   fonts-tlwg-mono-otf \
+  fonts-tlwg-mono-ttf \
+  fonts-tlwg-norasi \
   fonts-tlwg-norasi-otf \
+  fonts-tlwg-norasi-ttf \
+  fonts-tlwg-purisa \
   fonts-tlwg-purisa-otf \
+  fonts-tlwg-purisa-ttf \
+  fonts-tlwg-sawasdee \
   fonts-tlwg-sawasdee-otf \
+  fonts-tlwg-sawasdee-ttf \
+  fonts-tlwg-typewriter \
   fonts-tlwg-typewriter-otf \
+  fonts-tlwg-typewriter-ttf \
+  fonts-tlwg-typist \
   fonts-tlwg-typist-otf \
+  fonts-tlwg-typist-ttf \
+  fonts-tlwg-typo \
   fonts-tlwg-typo-otf \
+  fonts-tlwg-typo-ttf \
+  fonts-tlwg-umpush \
   fonts-tlwg-umpush-otf \
+  fonts-tlwg-umpush-ttf \
+  fonts-tlwg-waree \
   fonts-tlwg-waree-otf \
+  fonts-tlwg-waree-ttf \
   fonts-tomsontalks \
   fonts-train \
   fonts-triod-postnaja \
+  fonts-tt2020 \
   fonts-tuffy \
+  fonts-ubuntu \
+  fonts-ubuntu-classic \
+  fonts-ubuntu-console \
   fonts-ubuntu-title \
+  fonts-ukij-uyghur \
   fonts-umeplus \
   fonts-umeplus-cl \
   fonts-unfonts-core \
   fonts-unfonts-extra \
   fonts-unifont \
   fonts-unikurdweb \
+  fonts-uniol \
   fonts-uralic \
+  fonts-urw-base35 \
+  fonts-vazirmatn \
   fonts-vlgothic \
   fonts-vollkorn \
   fonts-wine \
-  fonts-woowa-bm
-
-RUN apt-get install -y \
+  fonts-woowa-bm \
   fonts-wqy-microhei \
   fonts-wqy-zenhei \
+  fonts-xfree86-nonfree \
+  fonts-xfree86-nonfree-syriac \
   fonts-yanone-kaffeesatz \
+  fonts-yas \
   fonts-yozvox-yozfont \
   fonts-yozvox-yozfont-antique \
   fonts-yozvox-yozfont-cute \
   fonts-yozvox-yozfont-edu \
   fonts-yozvox-yozfont-new-kana \
   fonts-yozvox-yozfont-standard-kana \
-  fonts-yusei-magic \
-  fonts-cns11643-kai \
-  fonts-cns11643-sung \
-  fonts-ibm-plex \
-  fonts-ipafont-nonfree-jisx0208 \
-  fonts-ipafont-nonfree-uigothic \
-  fonts-jetbrains-mono \
-  fonts-larabie-deco \
-  fonts-larabie-straight \
-  fonts-larabie-uncommon \
-  fonts-mikachan \
-  fonts-moe-standard-kai \
-  fonts-moe-standard-song \
-  fonts-mononoki \
-  fonts-xfree86-nonfree \
-  fonts-xfree86-nonfree-syriac
+  fonts-yrsa-rasa \
+  fonts-yusei-magic
 
 RUN apk add --no-cache \
   tesseract-ocr \

--- a/conversion/Dockerfile
+++ b/conversion/Dockerfile
@@ -582,7 +582,7 @@ RUN apt-get install -y \
   fonts-yrsa-rasa \
   fonts-yusei-magic
 
-RUN apk add --no-cache \
+RUN apt-get install -y \
   tesseract-ocr \
   tesseract-ocr-data-osd \
   tesseract-ocr-data-ara \

--- a/conversion/Dockerfile
+++ b/conversion/Dockerfile
@@ -36,8 +36,8 @@ RUN apt-get install -y \
 
 RUN npm i -g gltf-pipeline
 RUN npm i -g @koupr/screenshot-glb
-RUN npx playwright install
 RUN npx playwright install-deps
+RUN npx playwright install
 
 RUN apt-get install -y \
   libreoffice-core-nogui \

--- a/conversion/Dockerfile
+++ b/conversion/Dockerfile
@@ -8,7 +8,7 @@
 # by the GNU Affero General Public License v3.0 only, included in the file
 # licenses/AGPL.txt.
 
-FROM golang:1.22-alpine AS builder
+FROM golang:1.22-bookworm AS builder
 
 WORKDIR /build
 
@@ -17,295 +17,565 @@ COPY . .
 RUN go mod download
 RUN go build -o voltaserve-conversion
 
-FROM zenika/alpine-chrome:124-with-playwright
+FROM ubuntu:noble
 
-USER root
+RUN apt-get update
 
-RUN apk update
-
-RUN apk add --no-cache \
+RUN apt-get install -y \
   curl \
   ffmpeg \
   gawk \
   ghostscript \
   imagemagick \
   poppler-utils \
-  exiftool \
+  libimage-exiftool-perl \
   ocrmypdf \
-  unzip
+  unzip \
+  nodejs \
+  npm
 
 RUN npm i -g gltf-pipeline
-RUN npm i -g @shopify/screenshot-glb
+RUN npm i -g @koupr/screenshot-glb
 
-RUN apk add --no-cache \
-  libreoffice-writer \
-  libreoffice-calc \
-  libreoffice-impress \
-  libreoffice-draw \
-  libreoffice-math
+RUN apt-get install -y \
+  libreoffice-core-nogui \
+  libreoffice-writer-nogui \
+  libreoffice-calc-nogui \
+  libreoffice-impress-nogui \
+  libreoffice-draw-nogui \
+  libreoffice-math-nogui
 
-RUN apk add --no-cache \
-  font-adobe-100dpi \
-  font-adobe-100dpi-doc \
-  font-adobe-75dpi \
-  font-adobe-75dpi-doc \
-  font-adobe-source-code-pro \
-  font-adobe-utopia-100dpi \
-  font-adobe-utopia-100dpi-doc \
-  font-adobe-utopia-75dpi \
-  font-adobe-utopia-75dpi-doc \
-  font-adobe-utopia-type1 \
-  font-adobe-utopia-type1-doc \
-  font-alias \
-  font-alias-doc \
-  font-anonymous-pro-nerd \
-  font-arabic-misc \
-  font-arimo \
-  font-arimo-nerd \
-  font-awesome \
-  font-awesome-brands \
-  font-awesome-free \
-  font-b612 \
-  font-b612-mono \
-  font-bakoma \
-  font-bakoma-doc \
-  font-bakoma-otf \
-  font-bakoma-ttf \
-  font-barlow \
-  font-bh-100dpi \
-  font-bh-100dpi-doc \
-  font-bh-75dpi \
-  font-bh-75dpi-doc \
-  font-bitstream-100dpi \
-  font-bitstream-100dpi-doc \
-  font-bitstream-75dpi \
-  font-bitstream-75dpi-doc \
-  font-bitstream-type1 \
-  font-bitstream-type1-doc \
-  font-bitstrom-wera-sans-mono-nerd \
-  font-cantarell \
-  font-carlito \
-  font-cascadia-code-nerd \
-  font-comic-shanns-mono-nerd \
-  font-cronyx-cyrillic \
-  font-cronyx-cyrillic-doc \
-  font-croscore \
-  font-cursor-misc \
-  font-dec-misc \
-  font-degheest \
-  font-dejavu \
-  font-dejavu-sans-mono-nerd \
-  font-droid \
-  font-droid-nonlatin \
-  font-droid-sans-mono-nerd \
-  font-dseg \
-  font-eb-garamond \
-  font-fira-code-nerd \
-  font-fira-mono-nerd \
-  font-freefont \
-  font-freefont-doc \
-  font-go-mono-nerd \
-  font-hack \
-  font-hack-nerd \
-  font-happy-times \
-  font-hasklig-nerd \
-  font-hermit-nerd \
-  font-ia-writer-nerd \
-  font-ibm-plex-mono-nerd \
-  font-ibm-type1 \
-  font-ibm-type1-doc \
-  font-inconsolata \
-  font-inconsolata-nerd \
-  font-inter \
-  font-iosevka \
-  font-iosevka-aile \
-  font-iosevka-base \
-  font-iosevka-curly \
-  font-iosevka-curly-slab \
-  font-iosevka-slab \
-  font-ipa \
-  font-ipaex \
-  font-isas-misc \
-  font-isas-misc-doc \
-  font-jetbrains-mono \
-  font-jetbrains-mono-nerd \
-  font-jetbrains-mono-nl \
-  font-jetbrains-mono-vf \
-  font-jis-misc \
-  font-jis-misc-doc \
-  font-karrik \
-  font-liberation \
-  font-liberation-mono-nerd \
-  font-liberation-sans-narrow \
-  font-linux-libertine \
-  font-manager \
-  font-manager-common \
-  font-manager-doc \
-  font-manager-lang \
-  font-manager-nemo \
-  font-manager-thunar \
-  font-meslo-nerd \
-  font-micro-misc \
-  font-misc-cyrillic \
-  font-misc-cyrillic-doc \
-  font-misc-ethiopic \
-  font-misc-misc \
-  font-monofur-nerd \
-  font-mononoki \
-  font-mononoki-nerd \
-  font-montserrat \
-  font-mutt-misc \
-  font-noto \
-  font-noto-adlam \
-  font-noto-ahom \
-  font-noto-all \
-  font-noto-arabic \
-  font-noto-armenian \
-  font-noto-balinese \
-  font-noto-bamum \
-  font-noto-bassa-vah \
-  font-noto-batak \
-  font-noto-bengali \
-  font-noto-buginese \
-  font-noto-buhid \
-  font-noto-canadian-aboriginal \
-  font-noto-chakma \
-  font-noto-cham \
-  font-noto-cherokee \
-  font-noto-chorasmian \
-  font-noto-cjk \
-  font-noto-cjk-extra \
-  font-noto-common \
-  font-noto-coptic \
-  font-noto-cypro-minoan \
-  font-noto-devanagari \
-  font-noto-dives-akuru \
-  font-noto-duployan \
-  font-noto-elbasan \
-  font-noto-emoji \
-  font-noto-ethiopic \
-  font-noto-extra \
-  font-noto-fangsong \
-  font-noto-georgian \
-  font-noto-grantha \
-  font-noto-gujarati \
-  font-noto-gunjala-gondi \
-  font-noto-gurmukhi \
-  font-noto-hanifi-rohingya \
-  font-noto-hanunoo \
-  font-noto-hebrew \
-  font-noto-historical \
-  font-noto-indic-siyaq-numbers \
-  font-noto-javanese \
-  font-noto-kaithi \
-  font-noto-kannada \
-  font-noto-kawi \
-  font-noto-kayah-li \
-  font-noto-khitan-small-script \
-  font-noto-khmer \
-  font-noto-khojki \
-  font-noto-lao \
-  font-noto-lepcha \
-  font-noto-limbu \
-  font-noto-lisu \
-  font-noto-makasar \
-  font-noto-malayalam \
-  font-noto-masaram-gondi \
-  font-noto-math \
-  font-noto-mayan-numerals \
-  font-noto-medefaidrin \
-  font-noto-meetei-mayek \
-  font-noto-mende-kikakui \
-  font-noto-miao \
-  font-noto-modi \
-  font-noto-mongolian \
-  font-noto-mro \
-  font-noto-music \
-  font-noto-myanmar \
-  font-noto-nag-mundari \
-  font-noto-nandinagari \
-  font-noto-naskh-arabic \
-  font-noto-nastaliq-urdu \
-  font-noto-new-tai-lue \
-  font-noto-newa \
-  font-noto-nko \
-  font-noto-nushu \
-  font-noto-nyiakeng-puachue-hmong \
-  font-noto-ol-chiki \
-  font-noto-old-uyghur \
-  font-noto-oriya \
-  font-noto-osage \
-  font-noto-ottoman-siyaq \
-  font-noto-pahawh-hmong \
-  font-noto-pau-cin-hau \
-  font-noto-rashi-hebrew \
-  font-noto-rejang \
-  font-noto-samaritan \
-  font-noto-saurashtra \
-  font-noto-sharada \
-  font-noto-signwriting \
-  font-noto-sinhala \
-  font-noto-sora-sompeng \
-  font-noto-soyombo \
-  font-noto-sundanese \
-  font-noto-syloti-nagri \
-  font-noto-symbols \
-  font-noto-syriac \
-  font-noto-tagbanwa \
-  font-noto-tai \
-  font-noto-tamil \
-  font-noto-tangsa \
-  font-noto-telugu \
-  font-noto-test \
-  font-noto-thaana \
-  font-noto-thai \
-  font-noto-tibetan \
-  font-noto-tifinagh \
-  font-noto-tirhuta \
-  font-noto-toto \
-  font-noto-vai \
-  font-noto-vithkuqi \
-  font-noto-wancho \
-  font-noto-warang-citi \
-  font-noto-yezidi \
-  font-noto-yi \
-  font-nunito \
-  font-opensans \
-  font-overpass \
-  font-overpass-nerd \
-  font-parisienne \
-  font-roboto \
-  font-roboto-flex \
-  font-roboto-mono \
-  font-schumacher-misc \
-  font-screen-cyrillic \
-  font-screen-cyrillic-doc \
-  font-share-tech-mono-nerd \
-  font-sligoil \
-  font-sony-misc \
-  font-source-code-pro-nerd \
-  font-space-mono-nerd \
-  font-sun-misc \
-  font-terminus \
-  font-terminus-doc \
-  font-terminus-nerd \
-  font-tinos-nerd \
-  font-tlwg \
-  font-ubuntu \
-  font-ubuntu-mono-nerd \
-  font-ubuntu-nerd \
-  font-unifont \
-  font-urw-base35 \
-  font-util \
-  font-util-dev \
-  font-util-doc \
-  font-uw-ttyp0 \
-  font-victor-mono-nerd \
-  font-viewer \
-  font-vollkorn \
-  font-winitzki-cyrillic \
-  font-wqy-zenhei \
-  font-xfree86-type1
+RUN apt-get install -y \
+  fonts-arphic-ukai \
+  fonts-arphic-uming \
+  fonts-beng \
+  fonts-beng-extra \
+  fonts-dejavu-core \
+  fonts-dejavu-extra \
+  fonts-deva \
+  fonts-deva-extra \
+  fonts-droid-fallback \
+  fonts-farsiweb \
+  fonts-font-awesome \
+  fonts-freefont-ttf \
+  fonts-gargi \
+  fonts-gubbi \
+  fonts-gujr \
+  fonts-gujr-extra \
+  fonts-guru \
+  fonts-guru-extra \
+  fonts-hosny-amiri \
+  fonts-indic \
+  fonts-kacst \
+  fonts-kacst-one \
+  fonts-kalapi \
+  fonts-khmeros \
+  fonts-khmeros-core \
+  fonts-knda \
+  fonts-lao \
+  fonts-lato \
+  fonts-liberation \
+  fonts-liberation2 \
+  fonts-lklug-sinhala
+
+RUN apt-get install -y \
+  fonts-lohit-beng-assamese \
+  fonts-lohit-beng-bengali \
+  fonts-lohit-deva \
+  fonts-lohit-gujr \
+  fonts-lohit-guru \
+  fonts-lohit-knda \
+  fonts-lohit-mlym \
+  fonts-lohit-orya \
+  fonts-lohit-taml \
+  fonts-lohit-taml-classical \
+  fonts-lohit-telu \
+  fonts-manchufont \
+  fonts-mathjax \
+  fonts-mlym \
+  fonts-nafees \
+  fonts-nakula \
+  fonts-navilu \
+  fonts-noto-cjk \
+  fonts-noto-cjk-extra \
+  fonts-noto-color-emoji \
+  fonts-noto-core \
+  fonts-noto-mono \
+  fonts-noto-ui-core \
+  fonts-opensymbol \
+  fonts-orya \
+  fonts-orya-extra \
+  fonts-pagul \
+  fonts-sahadeva \
+  fonts-samyak-deva \
+  fonts-samyak-gujr \
+  fonts-samyak-mlym \
+  fonts-samyak-taml \
+  fonts-sarai \
+  fonts-sil-abyssinica \
+  fonts-sil-ezra \
+  fonts-sil-nuosusil \
+  fonts-sil-padauk \
+  fonts-sil-scheherazade \
+  fonts-smc
+
+RUN apt-get install -y \
+  fonts-smc-anjalioldlipi \
+  fonts-smc-chilanka \
+  fonts-smc-dyuthi \
+  fonts-smc-gayathri \
+  fonts-smc-karumbi \
+  fonts-smc-keraleeyam \
+  fonts-smc-manjari \
+  fonts-smc-meera \
+  fonts-smc-rachana \
+  fonts-smc-raghumalayalamsans \
+  fonts-smc-suruma \
+  fonts-smc-uroob \
+  fonts-taml \
+  fonts-telu \
+  fonts-telu-extra \
+  fonts-teluguvijayam \
+  fonts-thai-tlwg \
+  fonts-tibetan-machine \
+  fonts-tlwg-garuda \
+  fonts-tlwg-garuda-ttf \
+  fonts-tlwg-kinnari \
+  fonts-tlwg-kinnari-ttf \
+  fonts-tlwg-laksaman \
+  fonts-tlwg-laksaman-ttf \
+  fonts-tlwg-loma \
+  fonts-tlwg-loma-ttf
+
+RUN apt-get install -y \
+  fonts-tlwg-mono \
+  fonts-tlwg-mono-ttf \
+  fonts-tlwg-norasi \
+  fonts-tlwg-norasi-ttf \
+  fonts-tlwg-purisa \
+  fonts-tlwg-purisa-ttf \
+  fonts-tlwg-sawasdee \
+  fonts-tlwg-sawasdee-ttf \
+  fonts-tlwg-typewriter \
+  fonts-tlwg-typewriter-ttf \
+  fonts-tlwg-typist \
+  fonts-tlwg-typist-ttf \
+  fonts-tlwg-typo \
+  fonts-tlwg-typo-ttf \
+  fonts-tlwg-umpush \
+  fonts-tlwg-umpush-ttf \
+  fonts-tlwg-waree \
+  fonts-tlwg-waree-ttf \
+  fonts-ubuntu \
+  fonts-ubuntu-console \
+  fonts-ukij-uyghur \
+  fonts-urw-base35 \
+  fonts-yrsa-rasa \
+  fonts-3270 \
+  fonts-adf-accanthis \
+  fonts-adf-baskervald \
+  fonts-adf-berenis \
+  fonts-adf-gillius \
+  fonts-adf-ikarius \
+  fonts-adf-irianis \
+  fonts-adf-libris \
+  fonts-adf-mekanus \
+  fonts-adf-oldania \
+  fonts-adf-romande
+
+RUN apt-get install -y \
+  fonts-adf-solothurn \
+  fonts-adf-switzera \
+  fonts-adf-tribun \
+  fonts-adf-universalis \
+  fonts-adf-verana \
+  fonts-aenigma \
+  fonts-agave \
+  fonts-aksharyogini2 \
+  fonts-alee \
+  fonts-alegreya-sans \
+  fonts-allerta \
+  fonts-amiga \
+  fonts-ancient-scripts \
+  fonts-anonymous-pro \
+  fonts-aoyagi-kouzan-t \
+  fonts-aoyagi-soseki \
+  fonts-apropal \
+  fonts-arabeyes \
+  fonts-arapey \
+  fonts-arkpandora \
+  fonts-arphic-bkai00mp \
+  fonts-arphic-bsmi00lp \
+  fonts-arphic-gbsn00lp \
+  fonts-arphic-gkai00mp \
+  fonts-arundina \
+  fonts-atarismall \
+  fonts-averia-gwf \
+  fonts-averia-sans-gwf \
+  fonts-averia-serif-gwf \
+  fonts-b612 \
+  fonts-babelstone-han \
+  fonts-babelstone-modern \
+  fonts-baekmuk \
+  fonts-bajaderka \
+  fonts-bebas-neue \
+  fonts-beteckna \
+  fonts-blankenburg \
+  fonts-bpg-georgian \
+  fonts-breip \
+  fonts-bwht \
+  fonts-cabin \
+  fonts-cabinsketch \
+  fonts-campania \
+  fonts-cantarell \
+  fonts-cardo \
+  fonts-cascadia-code \
+  fonts-cegui \
+  fonts-century-catalogue \
+  fonts-cherrybomb
+
+RUN apt-get install -y \
+  fonts-circos-symbols \
+  fonts-clear-sans \
+  fonts-cmu \
+  fonts-comfortaa \
+  fonts-comic-neue \
+  fonts-compagnon \
+  fonts-courier-prime \
+  fonts-creep2 \
+  fonts-croscore \
+  fonts-crosextra-caladea \
+  fonts-crosextra-carlito \
+  fonts-cwtex-docs \
+  fonts-cwtex-fs \
+  fonts-cwtex-heib \
+  fonts-cwtex-kai \
+  fonts-cwtex-ming \
+  fonts-cwtex-yen \
+  fonts-dancingscript \
+  fonts-ddc-uchen \
+  fonts-dejavu \
+  fonts-dejima-mincho \
+  fonts-denemo \
+  fonts-dkg-handwriting \
+  fonts-dosis \
+  fonts-dotgothic16 \
+  fonts-dseg \
+  fonts-dustin \
+  fonts-dzongkha \
+  fonts-ebgaramond \
+  fonts-ebgaramond-extra \
+  fonts-ecolier-court \
+  fonts-ecolier-lignes-court \
+  fonts-eeyek \
+  fonts-elstob \
+  fonts-elusive-icons \
+  fonts-emojione \
+  fonts-engadget \
+  fonts-entypo \
+  fonts-essays1743 \
+  fonts-eurofurence \
+  fonts-evertype-conakry \
+  fonts-f500 \
+  fonts-fantasma
+
+RUN apt-get install -y \
+  fonts-fantasque-sans \
+  fonts-fanwood \
+  fonts-femkeklaver \
+  fonts-ferrite-core \
+  fonts-firacode \
+  fonts-fork-awesome \
+  fonts-freefarsi \
+  fonts-freefont-otf \
+  fonts-gamaliel \
+  fonts-gemunu-libre \
+  fonts-georgewilliams \
+  fonts-gfs-artemisia \
+  fonts-gfs-baskerville \
+  fonts-gfs-bodoni-classic \
+  fonts-gfs-complutum \
+  fonts-gfs-didot \
+  fonts-gfs-didot-classic \
+  fonts-gfs-gazis \
+  fonts-gfs-neohellenic \
+  fonts-gfs-olga \
+  fonts-gfs-porson \
+  fonts-gfs-solomos \
+  fonts-gfs-theokritos \
+  fonts-glasstty \
+  fonts-glyphicons-halflings \
+  fonts-gnutypewriter \
+  fonts-go \
+  fonts-gotico-antiqua \
+  fonts-goudybookletter \
+  fonts-hack \
+  fonts-hack-otf \
+  fonts-hack-ttf \
+  fonts-hack-web \
+  fonts-hanazono \
+  fonts-havana \
+  fonts-hermit \
+  fonts-horai-umefont \
+  fonts-hosny-thabit \
+  fonts-humor-sans
+
+RUN apt-get install -y \
+  fonts-inconsolata \
+  fonts-inter \
+  fonts-inter-variable \
+  fonts-ipaexfont \
+  fonts-ipaexfont-gothic \
+  fonts-ipaexfont-mincho \
+  fonts-ipafont \
+  fonts-ipafont-gothic \
+  fonts-ipafont-mincho \
+  fonts-ipamj-mincho \
+  fonts-isabella \
+  fonts-johnsmith-induni \
+  fonts-joscelyn \
+  fonts-jsmath \
+  fonts-junction \
+  fonts-junicode \
+  fonts-jura \
+  fonts-kanjistrokeorders \
+  fonts-karla \
+  fonts-karmilla \
+  fonts-katex \
+  fonts-kaushanscript \
+  fonts-kiloji \
+  fonts-klaudia-berenika \
+  fonts-klee \
+  fonts-komatuna \
+  fonts-konatu \
+  fonts-kouzan-mouhitsu \
+  fonts-kristi \
+  fonts-ldco \
+  fonts-le-murmure \
+  fonts-league-mono \
+  fonts-league-spartan \
+  fonts-leckerli-one \
+  fonts-lemonada \
+  fonts-levien-museum \
+  fonts-levien-typoscript \
+  fonts-lexi-gulim \
+  fonts-lexi-saebom \
+  fonts-lg-aboriginal \
+  fonts-libfinal \
+  fonts-lindenhill \
+  fonts-linex \
+  fonts-linuxlibertine \
+  fonts-lmodern \
+  fonts-lobster \
+  fonts-lobstertwo \
+  fonts-lohit-deva-marathi \
+  fonts-lohit-deva-nepali \
+  fonts-lyx \
+  fonts-manrope \
+  fonts-material-design-icons-iconfont \
+  fonts-materialdesignicons-webfont \
+  fonts-mathjax-extras
+
+RUN apt-get install -y \
+  fonts-meera-inimai \
+  fonts-meera-taml \
+  fonts-migmix \
+  fonts-millimetre \
+  fonts-misaki \
+  fonts-mmcedar \
+  fonts-mona \
+  fonts-monapo \
+  fonts-monlam \
+  fonts-monofur \
+  fonts-monoid \
+  fonts-monoid-halfloose \
+  fonts-monoid-halftight \
+  fonts-monoid-loose \
+  fonts-monoid-tight \
+  fonts-motoya-l-cedar \
+  fonts-motoya-l-maruberi \
+  fonts-mph-2b-damase \
+  fonts-mplus \
+  fonts-myanmar \
+  fonts-nanum \
+  fonts-nanum-coding \
+  fonts-nanum-eco \
+  fonts-nanum-extra \
+  fonts-national-park \
+  fonts-naver-d2coding \
+  fonts-noto \
+  fonts-noto-extra \
+  fonts-noto-hinted \
+  fonts-noto-ui-extra \
+  fonts-noto-unhinted \
+  fonts-ocr-a \
+  fonts-ocr-b \
+  fonts-octicons \
+  fonts-oflb-asana-math \
+  fonts-oflb-euterpe \
+  fonts-okolaks \
+  fonts-oldstandard \
+  fonts-open-sans \
+  fonts-opendin \
+  fonts-opendyslexic \
+  fonts-oradano-mincho-gsrr \
+  fonts-osifont \
+  fonts-oxygen \
+  fonts-paktype \
+  fonts-paratype \
+  fonts-pc \
+  fonts-pc-extra \
+  fonts-pecita \
+  fonts-play
+
+RUN apt-get install -y \
+  fonts-povray \
+  fonts-powerline \
+  fonts-prociono \
+  fonts-proggy \
+  fonts-quattrocento \
+  fonts-quicksand \
+  fonts-radisnoir \
+  fonts-rampart \
+  fonts-recommended \
+  fonts-reggae \
+  fonts-ricty-diminished \
+  fonts-rit-sundar \
+  fonts-roadgeek \
+  fonts-roboto \
+  fonts-roboto-fontface \
+  fonts-roboto-hinted \
+  fonts-roboto-slab \
+  fonts-roboto-unhinted \
+  fonts-rocknroll \
+  fonts-rufscript \
+  fonts-sambhota-tsugring \
+  fonts-sambhota-yigchung \
+  fonts-samyak \
+  fonts-samyak-orya \
+  fonts-sawarabi-gothic \
+  fonts-sawarabi-mincho \
+  fonts-senamirmir-washra \
+  fonts-seto \
+  fonts-sil-akatab \
+  fonts-sil-alkalami \
+  fonts-sil-andika \
+  fonts-sil-andika-compact \
+  fonts-sil-andikanewbasic \
+  fonts-sil-annapurna \
+  fonts-sil-awami-nastaliq \
+  fonts-sil-charis \
+  fonts-sil-charis-compact \
+  fonts-sil-dai-banna \
+  fonts-sil-doulos \
+  fonts-sil-doulos-compact \
+  fonts-sil-galatia \
+  fonts-sil-gentium \
+  fonts-sil-gentium-basic \
+  fonts-sil-gentiumplus \
+  fonts-sil-gentiumplus-compact \
+  fonts-sil-harmattan \
+  fonts-sil-lateef \
+  fonts-sil-mingzat \
+  fonts-sil-mondulkiri \
+  fonts-sil-mondulkiri-extra \
+  fonts-sil-shimenkan \
+  fonts-sil-shimenkan-gsm
+
+RUN apt-get install -y \
+  fonts-sil-shimenkan-guifan \
+  fonts-sil-shimenkan-mas \
+  fonts-sil-shimenkan-mgs \
+  fonts-sil-shimenkan-salaowu \
+  fonts-sil-shimenkan-sapushan \
+  fonts-sil-shimenkan-taogu \
+  fonts-sil-shimenkan-zonghe \
+  fonts-sil-sophia-nubian \
+  fonts-sil-tagmukay \
+  fonts-sil-taiheritagepro \
+  fonts-sil-zaghawa-beria \
+  fonts-sipa-arundina \
+  fonts-sixtyfour \
+  fonts-sjfonts \
+  fonts-solide-mirage \
+  fonts-sora \
+  fonts-spleen \
+  fonts-staypuft \
+  fonts-stick \
+  fonts-stix \
+  fonts-summersby \
+  fonts-symbola \
+  fonts-takao \
+  fonts-takao-gothic \
+  fonts-takao-mincho \
+  fonts-takao-pgothic \
+  fonts-taml-tamu \
+  fonts-taml-tscu \
+  fonts-terminus \
+  fonts-terminus-otb \
+  fonts-texgyre \
+  fonts-thai-tlwg-otf \
+  fonts-thai-tlwg-ttf \
+  fonts-thai-tlwg-web \
+  fonts-tiresias \
+  fonts-tlwg-garuda-otf \
+  fonts-tlwg-kinnari-otf \
+  fonts-tlwg-laksaman-otf \
+  fonts-tlwg-loma-otf
+
+RUN apt-get install -y \
+  fonts-tlwg-mono-otf \
+  fonts-tlwg-norasi-otf \
+  fonts-tlwg-purisa-otf \
+  fonts-tlwg-sawasdee-otf \
+  fonts-tlwg-typewriter-otf \
+  fonts-tlwg-typist-otf \
+  fonts-tlwg-typo-otf \
+  fonts-tlwg-umpush-otf \
+  fonts-tlwg-waree-otf \
+  fonts-tomsontalks \
+  fonts-train \
+  fonts-triod-postnaja \
+  fonts-tuffy \
+  fonts-ubuntu-title \
+  fonts-umeplus \
+  fonts-umeplus-cl \
+  fonts-unfonts-core \
+  fonts-unfonts-extra \
+  fonts-unifont \
+  fonts-unikurdweb \
+  fonts-uralic \
+  fonts-vlgothic \
+  fonts-vollkorn \
+  fonts-wine \
+  fonts-woowa-bm
+
+RUN apt-get install -y \
+  fonts-wqy-microhei \
+  fonts-wqy-zenhei \
+  fonts-yanone-kaffeesatz \
+  fonts-yozvox-yozfont \
+  fonts-yozvox-yozfont-antique \
+  fonts-yozvox-yozfont-cute \
+  fonts-yozvox-yozfont-edu \
+  fonts-yozvox-yozfont-new-kana \
+  fonts-yozvox-yozfont-standard-kana \
+  fonts-yusei-magic \
+  fonts-cns11643-kai \
+  fonts-cns11643-sung \
+  fonts-ibm-plex \
+  fonts-ipafont-nonfree-jisx0208 \
+  fonts-ipafont-nonfree-uigothic \
+  fonts-jetbrains-mono \
+  fonts-larabie-deco \
+  fonts-larabie-straight \
+  fonts-larabie-uncommon \
+  fonts-mikachan \
+  fonts-moe-standard-kai \
+  fonts-moe-standard-song \
+  fonts-mononoki \
+  fonts-xfree86-nonfree \
+  fonts-xfree86-nonfree-syriac
 
 RUN apk add --no-cache \
   tesseract-ocr \
@@ -318,6 +588,18 @@ RUN apk add --no-cache \
   tesseract-ocr-data-deu \
   tesseract-ocr-data-por \
   tesseract-ocr-data-spa
+
+RUN apt-get install -y \
+  tesseract-ocr \
+  tesseract-ocr-osd \
+  tesseract-ocr-ara \
+  tesseract-ocr-chi-sim \
+  tesseract-ocr-chi-tra \
+  tesseract-ocr-eng \
+  tesseract-ocr-fra \
+  tesseract-ocr-deu \
+  tesseract-ocr-por \
+  tesseract-ocr-spa
 
 WORKDIR /app
 

--- a/conversion/Dockerfile
+++ b/conversion/Dockerfile
@@ -550,7 +550,6 @@ RUN apt-get install -y \
   fonts-tt2020 \
   fonts-tuffy \
   fonts-ubuntu \
-  fonts-ubuntu-classic \
   fonts-ubuntu-console \
   fonts-ubuntu-title \
   fonts-ukij-uyghur \

--- a/conversion/Dockerfile
+++ b/conversion/Dockerfile
@@ -608,6 +608,18 @@ RUN apt-get install -y \
   tesseract-ocr-por \
   tesseract-ocr-spa
 
+RUN apt-get install -y \
+  tesseract-ocr \
+  tesseract-ocr-osd \
+  tesseract-ocr-ara \
+  tesseract-ocr-chi-sim \
+  tesseract-ocr-chi-tra \
+  tesseract-ocr-eng \
+  tesseract-ocr-fra \
+  tesseract-ocr-deu \
+  tesseract-ocr-por \
+  tesseract-ocr-spa
+
 WORKDIR /app
 
 COPY --from=builder /build/voltaserve-conversion ./voltaserve-conversion


### PR DESCRIPTION
Here we are using headless WebKit instead of Chrome to generate thumbnails for GLB 3D models.
Also switching this container from Alpine Linux to Debian/Ubuntu because it has better support for the latest WebKit.

The problem with the Chrome implementation is that it was unreliable under container environments, sometimes works sometimes not, that's because Chrome is a memory hog, unpredictable and not very portable.
WebKit being lightweight, consistent, available in many platforms, and easy to build, it seems to be the right choice.

Now we are using [`@koupr/screenshot-glb`](https://www.npmjs.com/package/@koupr/screenshot-glb) which uses the latest WebKit and [Playwright](https://playwright.dev/), instead of [`@shopify/screenshot-glb`](https://www.npmjs.com/package/@shopify/screenshot-glb) which uses an older version of [Puppeteer](https://pptr.dev/) and Chrome.

The fork in maintained here: https://github.com/kouprlabs/screenshot-glb

Closes #143
Solves #162 