### PR TITLE
fix(api): search pagination, format SQL queries

### DIFF
--- a/api/infra/search.go
+++ b/api/infra/search.go
@@ -118,8 +118,12 @@ func NewSearchManager() *SearchManager {
 	}
 }
 
-func (mgr *SearchManager) Query(index string, query string) ([]interface{}, error) {
-	res, err := searchClient.Index(index).Search(query, &meilisearch.SearchRequest{})
+type QueryOptions struct {
+	Limit int64
+}
+
+func (mgr *SearchManager) Query(index string, query string, opts QueryOptions) ([]interface{}, error) {
+	res, err := searchClient.Index(index).Search(query, &meilisearch.SearchRequest{Limit: opts.Limit})
 	if err != nil {
 		return nil, err
 	}

--- a/api/repo/task_repo.go
+++ b/api/repo/task_repo.go
@@ -146,6 +146,7 @@ func (s *taskEntity) SetPayload(p map[string]string) {
 type TaskRepo interface {
 	Insert(opts TaskInsertOptions) (model.Task, error)
 	Find(id string) (model.Task, error)
+	Count() (int64, error)
 	GetIDs(userID string) ([]string, error)
 	GetCount(email string) (int64, error)
 	Save(task model.Task) error
@@ -225,12 +226,28 @@ func (repo *taskRepo) Find(id string) (model.Task, error) {
 	return res, nil
 }
 
+func (repo *taskRepo) Count() (int64, error) {
+	type Result struct {
+		Result int64
+	}
+	var res Result
+	db := repo.db.
+		Raw("SELECT count(*) as result FROM task").
+		Scan(&res)
+	if db.Error != nil {
+		return 0, db.Error
+	}
+	return res.Result, nil
+}
+
 func (repo *taskRepo) GetIDs(userID string) ([]string, error) {
 	type Value struct {
 		Result string
 	}
 	var values []Value
-	db := repo.db.Raw("SELECT id result FROM task WHERE user_id = ? ORDER BY create_time DESC", userID).Scan(&values)
+	db := repo.db.
+		Raw("SELECT id result FROM task WHERE user_id = ? ORDER BY create_time DESC", userID).
+		Scan(&values)
 	if db.Error != nil {
 		return []string{}, db.Error
 	}

--- a/api/repo/user_repo.go
+++ b/api/repo/user_repo.go
@@ -24,6 +24,7 @@ type UserRepo interface {
 	Find(id string) (model.User, error)
 	FindByEmail(email string) (model.User, error)
 	FindAll() ([]model.User, error)
+	Count() (int64, error)
 }
 
 func NewUserRepo() UserRepo {
@@ -124,7 +125,7 @@ func (repo *userRepo) FindByEmail(email string) (model.User, error) {
 
 func (repo *userRepo) FindAll() ([]model.User, error) {
 	var entities []*userEntity
-	db := repo.db.Raw(`select * from "user"`).Scan(&entities)
+	db := repo.db.Raw(`SELECT * FROM "user"`).Scan(&entities)
 	if db.Error != nil {
 		return nil, db.Error
 	}
@@ -133,4 +134,18 @@ func (repo *userRepo) FindAll() ([]model.User, error) {
 		res = append(res, u)
 	}
 	return res, nil
+}
+
+func (repo *userRepo) Count() (int64, error) {
+	type Result struct {
+		Result int64
+	}
+	var res Result
+	db := repo.db.
+		Raw(`SELECT count(*) as result FROM "user"`).
+		Scan(&res)
+	if db.Error != nil {
+		return 0, db.Error
+	}
+	return res.Result, nil
 }

--- a/api/search/file_search.go
+++ b/api/search/file_search.go
@@ -80,8 +80,8 @@ func (s *FileSearch) Delete(ids []string) error {
 	return nil
 }
 
-func (s *FileSearch) Query(query string) ([]model.File, error) {
-	hits, err := s.search.Query(s.index, query)
+func (s *FileSearch) Query(query string, opts infra.QueryOptions) ([]model.File, error) {
+	hits, err := s.search.Query(s.index, query, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/api/search/group_search.go
+++ b/api/search/group_search.go
@@ -70,8 +70,8 @@ func (s *GroupSearch) Delete(ids []string) error {
 	return nil
 }
 
-func (s *GroupSearch) Query(query string) ([]model.Group, error) {
-	hits, err := s.search.Query(s.index, query)
+func (s *GroupSearch) Query(query string, opts infra.QueryOptions) ([]model.Group, error) {
+	hits, err := s.search.Query(s.index, query, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/api/search/organization_search.go
+++ b/api/search/organization_search.go
@@ -70,8 +70,8 @@ func (s *OrganizationSearch) Delete(ids []string) error {
 	return nil
 }
 
-func (s *OrganizationSearch) Query(query string) ([]model.Organization, error) {
-	hits, err := s.search.Query(s.index, query)
+func (s *OrganizationSearch) Query(query string, opts infra.QueryOptions) ([]model.Organization, error) {
+	hits, err := s.search.Query(s.index, query, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/api/search/task_search.go
+++ b/api/search/task_search.go
@@ -70,8 +70,8 @@ func (s *TaskSearch) Delete(ids []string) error {
 	return nil
 }
 
-func (s *TaskSearch) Query(query string) ([]model.Task, error) {
-	hits, err := s.search.Query(s.index, query)
+func (s *TaskSearch) Query(query string, opts infra.QueryOptions) ([]model.Task, error) {
+	hits, err := s.search.Query(s.index, query, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/api/search/user_search.go
+++ b/api/search/user_search.go
@@ -30,8 +30,8 @@ func NewUserSearch() *UserSearch {
 	}
 }
 
-func (s *UserSearch) Query(query string) ([]model.User, error) {
-	hits, err := s.search.Query(s.index, query)
+func (s *UserSearch) Query(query string, opts infra.QueryOptions) ([]model.User, error) {
+	hits, err := s.search.Query(s.index, query, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/api/search/workspace_search.go
+++ b/api/search/workspace_search.go
@@ -70,8 +70,8 @@ func (s *WorkspaceSearch) Delete(ids []string) error {
 	return nil
 }
 
-func (s *WorkspaceSearch) Query(query string) ([]model.Workspace, error) {
-	hits, err := s.search.Query(s.index, query)
+func (s *WorkspaceSearch) Query(query string, opts infra.QueryOptions) ([]model.Workspace, error) {
+	hits, err := s.search.Query(s.index, query, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/api/service/group_service.go
+++ b/api/service/group_service.go
@@ -14,6 +14,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/kouprlabs/voltaserve/api/infra"
+
 	"github.com/kouprlabs/voltaserve/api/cache"
 	"github.com/kouprlabs/voltaserve/api/config"
 	"github.com/kouprlabs/voltaserve/api/guard"
@@ -170,7 +172,11 @@ func (svc *GroupService) List(opts GroupListOptions, userID string) (*GroupList,
 			}
 		}
 	} else {
-		groups, err := svc.groupSearch.Query(opts.Query)
+		count, err := svc.groupRepo.Count()
+		if err != nil {
+			return nil, err
+		}
+		groups, err := svc.groupSearch.Query(opts.Query, infra.QueryOptions{Limit: count})
 		if err != nil {
 			return nil, err
 		}

--- a/api/service/group_service.go
+++ b/api/service/group_service.go
@@ -14,12 +14,11 @@ import (
 	"sort"
 	"time"
 
-	"github.com/kouprlabs/voltaserve/api/infra"
-
 	"github.com/kouprlabs/voltaserve/api/cache"
 	"github.com/kouprlabs/voltaserve/api/config"
 	"github.com/kouprlabs/voltaserve/api/guard"
 	"github.com/kouprlabs/voltaserve/api/helper"
+	"github.com/kouprlabs/voltaserve/api/infra"
 	"github.com/kouprlabs/voltaserve/api/model"
 	"github.com/kouprlabs/voltaserve/api/repo"
 	"github.com/kouprlabs/voltaserve/api/search"

--- a/api/service/organization_service.go
+++ b/api/service/organization_service.go
@@ -14,13 +14,12 @@ import (
 	"sort"
 	"time"
 
-	"github.com/kouprlabs/voltaserve/api/infra"
-
 	"github.com/kouprlabs/voltaserve/api/cache"
 	"github.com/kouprlabs/voltaserve/api/config"
 	"github.com/kouprlabs/voltaserve/api/errorpkg"
 	"github.com/kouprlabs/voltaserve/api/guard"
 	"github.com/kouprlabs/voltaserve/api/helper"
+	"github.com/kouprlabs/voltaserve/api/infra"
 	"github.com/kouprlabs/voltaserve/api/log"
 	"github.com/kouprlabs/voltaserve/api/model"
 	"github.com/kouprlabs/voltaserve/api/repo"

--- a/api/service/organization_service.go
+++ b/api/service/organization_service.go
@@ -14,6 +14,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/kouprlabs/voltaserve/api/infra"
+
 	"github.com/kouprlabs/voltaserve/api/cache"
 	"github.com/kouprlabs/voltaserve/api/config"
 	"github.com/kouprlabs/voltaserve/api/errorpkg"
@@ -137,7 +139,11 @@ func (svc *OrganizationService) List(opts OrganizationListOptions, userID string
 			return nil, err
 		}
 	} else {
-		orgs, err := svc.orgSearch.Query(opts.Query)
+		count, err := svc.groupRepo.Count()
+		if err != nil {
+			return nil, err
+		}
+		orgs, err := svc.orgSearch.Query(opts.Query, infra.QueryOptions{Limit: count})
 		if err != nil {
 			return nil, err
 		}

--- a/api/service/task_service.go
+++ b/api/service/task_service.go
@@ -14,6 +14,8 @@ import (
 	"sort"
 	"time"
 
+	"github.com/kouprlabs/voltaserve/api/infra"
+
 	"github.com/kouprlabs/voltaserve/api/cache"
 	"github.com/kouprlabs/voltaserve/api/errorpkg"
 	"github.com/kouprlabs/voltaserve/api/helper"
@@ -175,7 +177,11 @@ func (svc *TaskService) List(opts TaskListOptions, userID string) (*TaskList, er
 			return nil, err
 		}
 	} else {
-		tasks, err := svc.taskSearch.Query(opts.Query)
+		count, err := svc.taskRepo.Count()
+		if err != nil {
+			return nil, err
+		}
+		tasks, err := svc.taskSearch.Query(opts.Query, infra.QueryOptions{Limit: count})
 		if err != nil {
 			return nil, err
 		}

--- a/api/service/task_service.go
+++ b/api/service/task_service.go
@@ -14,11 +14,10 @@ import (
 	"sort"
 	"time"
 
-	"github.com/kouprlabs/voltaserve/api/infra"
-
 	"github.com/kouprlabs/voltaserve/api/cache"
 	"github.com/kouprlabs/voltaserve/api/errorpkg"
 	"github.com/kouprlabs/voltaserve/api/helper"
+	"github.com/kouprlabs/voltaserve/api/infra"
 	"github.com/kouprlabs/voltaserve/api/model"
 	"github.com/kouprlabs/voltaserve/api/repo"
 	"github.com/kouprlabs/voltaserve/api/search"

--- a/api/service/user_service.go
+++ b/api/service/user_service.go
@@ -13,11 +13,10 @@ package service
 import (
 	"sort"
 
-	"github.com/kouprlabs/voltaserve/api/infra"
-
 	"github.com/kouprlabs/voltaserve/api/cache"
 	"github.com/kouprlabs/voltaserve/api/config"
 	"github.com/kouprlabs/voltaserve/api/guard"
+	"github.com/kouprlabs/voltaserve/api/infra"
 	"github.com/kouprlabs/voltaserve/api/model"
 	"github.com/kouprlabs/voltaserve/api/repo"
 	"github.com/kouprlabs/voltaserve/api/search"

--- a/api/service/user_service.go
+++ b/api/service/user_service.go
@@ -13,6 +13,8 @@ package service
 import (
 	"sort"
 
+	"github.com/kouprlabs/voltaserve/api/infra"
+
 	"github.com/kouprlabs/voltaserve/api/cache"
 	"github.com/kouprlabs/voltaserve/api/config"
 	"github.com/kouprlabs/voltaserve/api/guard"
@@ -23,6 +25,7 @@ import (
 
 type UserService struct {
 	userMapper *userMapper
+	userRepo   repo.UserRepo
 	userSearch *search.UserSearch
 	orgRepo    repo.OrganizationRepo
 	orgCache   *cache.OrganizationCache
@@ -36,6 +39,7 @@ type UserService struct {
 func NewUserService() *UserService {
 	return &UserService{
 		userMapper: newUserMapper(),
+		userRepo:   repo.NewUserRepo(),
 		userSearch: search.NewUserSearch(),
 		orgRepo:    repo.NewOrganizationRepo(),
 		orgCache:   cache.NewOrganizationCache(),
@@ -140,7 +144,11 @@ func (svc *UserService) List(opts UserListOptions, userID string) (*UserList, er
 			}
 		}
 	} else {
-		users, err := svc.userSearch.Query(opts.Query)
+		count, err := svc.userRepo.Count()
+		if err != nil {
+			return nil, err
+		}
+		users, err := svc.userSearch.Query(opts.Query, infra.QueryOptions{Limit: count})
 		if err != nil {
 			return nil, err
 		}

--- a/api/service/workspace_service.go
+++ b/api/service/workspace_service.go
@@ -178,7 +178,11 @@ func (svc *WorkspaceService) List(opts WorkspaceListOptions, userID string) (*Wo
 			return nil, err
 		}
 	} else {
-		workspaces, err := svc.workspaceSearch.Query(opts.Query)
+		count, err := svc.workspaceRepo.Count()
+		if err != nil {
+			return nil, err
+		}
+		workspaces, err := svc.workspaceSearch.Query(opts.Query, infra.QueryOptions{Limit: count})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
In this PR I did the following:
- I fix a bug that causes search results not to be paginated and limit itself to 20 items in the result even when more are available.
- Use Go multiline strings for SQL queries and format them so they look nice and consistent.

Closes #184