### PR TITLE
perf: reduce large file operations from minutes to seconds

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -12,6 +12,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/kouprlabs/voltaserve/api/service"
 	"os"
 	"strings"
 
@@ -107,6 +108,10 @@ func main() {
 
 	users := router.NewUserRouter()
 	users.AppendRoutes(v2.Group("users"))
+
+	if err := service.NewFileService().MigrateToPathField(); err != nil {
+		panic(err)
+	}
 
 	if err := app.Listen(fmt.Sprintf(":%d", cfg.Port)); err != nil {
 		panic(err)

--- a/api/main.go
+++ b/api/main.go
@@ -12,7 +12,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/kouprlabs/voltaserve/api/service"
 	"os"
 	"strings"
 
@@ -25,6 +24,7 @@ import (
 	"github.com/kouprlabs/voltaserve/api/errorpkg"
 	"github.com/kouprlabs/voltaserve/api/helper"
 	"github.com/kouprlabs/voltaserve/api/router"
+	"github.com/kouprlabs/voltaserve/api/service"
 )
 
 // @title		Voltaserve API

--- a/api/model/file_model.go
+++ b/api/model/file_model.go
@@ -21,6 +21,7 @@ type File interface {
 	GetName() string
 	GetType() string
 	GetParentID() *string
+	GetPath() string
 	GetCreateTime() string
 	GetUpdateTime() *string
 	GetUserPermissions() []CoreUserPermission
@@ -29,6 +30,7 @@ type File interface {
 	GetSnapshotID() *string
 	SetID(string)
 	SetParentID(*string)
+	SetPath(string)
 	SetWorkspaceID(string)
 	SetType(string)
 	SetName(string)

--- a/api/service/file_service.go
+++ b/api/service/file_service.go
@@ -1427,7 +1427,7 @@ func (svc *FileService) MigrateToPathField() error {
 }
 
 func (svc *FileService) IsGrandChildOf(file model.File, ancestor model.File) bool {
-	return strings.HasPrefix(file.GetPath(), ancestor.GetPath())
+	return strings.HasPrefix(file.GetPath(), ancestor.GetPath()) && len(file.GetPath()) > len(ancestor.GetPath())
 }
 
 func (svc *FileService) doAuthorization(data []model.File, userID string) ([]model.File, error) {

--- a/postgres/schema.sql
+++ b/postgres/schema.sql
@@ -57,6 +57,7 @@ CREATE TABLE IF NOT EXISTS "file"
     name         text NOT NULL,
     type         text NOT NULL,
     parent_id    text,
+    path         text NOT NULL DEFAULT '',
     workspace_id text REFERENCES workspace (id) ON DELETE CASCADE,
     snapshot_id  text,
     create_time  text NOT NULL DEFAULT (to_json(now())#>>'{}'),

--- a/ui/src/client/api/file.ts
+++ b/ui/src/client/api/file.ts
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the GNU Affero General Public License v3.0 only, included in the file
 // licenses/AGPL.txt.
-
 import useSWR, { SWRConfiguration } from 'swr'
 import { apiFetcher } from '@/client/fetcher'
 import { User } from '@/client/idp/user'
@@ -42,6 +41,7 @@ export type File = {
   name: string
   type: FileType
   parentId: string
+  path: string
   permission: PermissionType
   isShared: boolean
   snapshot?: Snapshot


### PR DESCRIPTION
After doing benchmarking and analyzing the SQL queries in CockroachDB console, I realized there is a heavy SQL query that is called on every file via the repository method `IsGrandChildOf()` when doing **move**, **copy**, and **search** operations.
To fix this, I had to introduce a `path` field that optimizes this.
Now move, copy and search operations that involve massive amounts of files is reduced from "seconds" to "milliseconds".
One search request that I benchmarked was reduced from **15 seconds** to **180 milliseconds**, it's _83 times faster!_