### PR TITLE
fix: permission system blockers

### DIFF
--- a/api/cache/group_cache.go
+++ b/api/cache/group_cache.go
@@ -66,3 +66,10 @@ func (c *GroupCache) Refresh(id string) (model.Group, error) {
 	}
 	return res, nil
 }
+
+func (c *GroupCache) Delete(id string) error {
+	if err := c.redis.Delete(c.keyPrefix + id); err != nil {
+		return err
+	}
+	return nil
+}

--- a/api/errorpkg/error_creators.go
+++ b/api/errorpkg/error_creators.go
@@ -243,11 +243,22 @@ func NewOrganizationPermissionError(userID string, org model.Organization, permi
 	)
 }
 
-func NewCannotRemoveLastRemainingOwnerOfOrganizationError(id string) *ErrorResponse {
+func NewCannotRemoveLastRemainingOwnerOfOrganizationError(org model.Organization) *ErrorResponse {
 	return NewErrorResponse(
 		"cannot_remove_last_owner_of_organization",
 		http.StatusBadRequest,
-		fmt.Sprintf("Cannot remove the last remaining owner of organization '%s'.", id), MsgInvalidRequest,
+		fmt.Sprintf("Cannot remove the last remaining owner of organization '%s'.", org.GetID()),
+		fmt.Sprintf("Cannot remove the last remaining owner of organization '%s'.", org.GetName()),
+		nil,
+	)
+}
+
+func NewCannotRemoveLastRemainingOwnerOfGroupError(group model.Group) *ErrorResponse {
+	return NewErrorResponse(
+		"cannot_remove_last_owner_of_group",
+		http.StatusBadRequest,
+		fmt.Sprintf("Cannot remove the last remaining owner of group '%s'.", group.GetID()),
+		fmt.Sprintf("Cannot remove the last remaining owner of group '%s'.", group.GetName()),
 		nil,
 	)
 }

--- a/api/repo/group_repo.go
+++ b/api/repo/group_repo.go
@@ -26,14 +26,12 @@ type GroupRepo interface {
 	Find(id string) (model.Group, error)
 	Count() (int64, error)
 	GetIDsForFile(fileID string) ([]string, error)
-	GetIDsForUser(userID string) ([]string, error)
 	GetIDsForOrganization(id string) ([]string, error)
 	Save(group model.Group) error
 	Delete(id string) error
-	AddUser(id string, userID string) error
-	RemoveMember(id string, userID string) error
 	GetIDs() ([]string, error)
 	GetMembers(id string) ([]model.User, error)
+	GetOwnerCount(id string) (int64, error)
 	GrantUserPermission(id string, userID string, permission string) error
 	RevokeUserPermission(id string, userID string) error
 }
@@ -214,22 +212,6 @@ func (repo *groupRepo) GetIDsForFile(fileID string) ([]string, error) {
 	return res, nil
 }
 
-func (repo *groupRepo) GetIDsForUser(userID string) ([]string, error) {
-	type Value struct {
-		Result string
-	}
-	var values []Value
-	db := repo.db.Raw(`SELECT group_id from group_user WHERE user_id = ?`, userID).Scan(&values)
-	if db.Error != nil {
-		return []string{}, db.Error
-	}
-	res := []string{}
-	for _, v := range values {
-		res = append(res, v.Result)
-	}
-	return res, nil
-}
-
 func (repo *groupRepo) GetIDsForOrganization(id string) ([]string, error) {
 	type Value struct {
 		Result string
@@ -270,22 +252,6 @@ func (repo *groupRepo) Delete(id string) error {
 	return nil
 }
 
-func (repo *groupRepo) AddUser(id string, userID string) error {
-	db := repo.db.Exec("INSERT INTO group_user (group_id, user_id, create_time) VALUES (?, ?, ?)", id, userID, helper.NewTimestamp())
-	if db.Error != nil {
-		return db.Error
-	}
-	return nil
-}
-
-func (repo *groupRepo) RemoveMember(id string, userID string) error {
-	db := repo.db.Exec("DELETE FROM group_user WHERE group_id = ? AND user_id = ?", id, userID)
-	if db.Error != nil {
-		return db.Error
-	}
-	return nil
-}
-
 func (repo *groupRepo) GetIDs() ([]string, error) {
 	type Value struct {
 		Result string
@@ -305,7 +271,8 @@ func (repo *groupRepo) GetIDs() ([]string, error) {
 func (repo *groupRepo) GetMembers(id string) ([]model.User, error) {
 	var entities []*userEntity
 	db := repo.db.
-		Raw(`SELECT DISTINCT u.* FROM "user" u INNER JOIN group_user gu ON u.id = gu.user_id WHERE gu.group_id = ?`, id).
+		Raw(`SELECT u.* FROM "user" u INNER JOIN userpermission up on
+             u.id = up.user_id AND up.resource_id = ?`, id).
 		Scan(&entities)
 	if db.Error != nil {
 		return nil, db.Error
@@ -315,6 +282,22 @@ func (repo *groupRepo) GetMembers(id string) ([]model.User, error) {
 		res = append(res, u)
 	}
 	return res, nil
+}
+
+func (repo *groupRepo) GetOwnerCount(id string) (int64, error) {
+	type Result struct {
+		Result int64
+	}
+	var res Result
+	db := repo.db.
+		Raw(`SELECT count(*) as result FROM userpermission
+             WHERE resource_id = ? and permission = ?`,
+			id, model.PermissionOwner).
+		Scan(&res)
+	if db.Error != nil {
+		return 0, db.Error
+	}
+	return res.Result, nil
 }
 
 func (repo *groupRepo) GrantUserPermission(id string, userID string, permission string) error {

--- a/api/repo/group_repo.go
+++ b/api/repo/group_repo.go
@@ -25,11 +25,11 @@ type GroupRepo interface {
 	Insert(opts GroupInsertOptions) (model.Group, error)
 	Find(id string) (model.Group, error)
 	Count() (int64, error)
-	GetIDsForFile(fileID string) ([]string, error)
-	GetIDsForOrganization(id string) ([]string, error)
+	GetIDs() ([]string, error)
+	GetIDsByFile(fileID string) ([]string, error)
+	GetIDsByOrganization(id string) ([]string, error)
 	Save(group model.Group) error
 	Delete(id string) error
-	GetIDs() ([]string, error)
 	GetMembers(id string) ([]model.User, error)
 	GetOwnerCount(id string) (int64, error)
 	GrantUserPermission(id string, userID string, permission string) error
@@ -191,7 +191,7 @@ func (repo *groupRepo) Count() (int64, error) {
 	return res.Result, nil
 }
 
-func (repo *groupRepo) GetIDsForFile(fileID string) ([]string, error) {
+func (repo *groupRepo) GetIDsByFile(fileID string) ([]string, error) {
 	type Value struct {
 		Result string
 	}
@@ -212,7 +212,7 @@ func (repo *groupRepo) GetIDsForFile(fileID string) ([]string, error) {
 	return res, nil
 }
 
-func (repo *groupRepo) GetIDsForOrganization(id string) ([]string, error) {
+func (repo *groupRepo) GetIDsByOrganization(id string) ([]string, error) {
 	type Value struct {
 		Result string
 	}

--- a/api/repo/snapshot_repo.go
+++ b/api/repo/snapshot_repo.go
@@ -30,7 +30,7 @@ type SnapshotRepo interface {
 	FindAllForFile(fileID string) ([]model.Snapshot, error)
 	FindAllDangling() ([]model.Snapshot, error)
 	FindAllPrevious(fileID string, version int64) ([]model.Snapshot, error)
-	GetIDsForFile(fileID string) ([]string, error)
+	GetIDsByFile(fileID string) ([]string, error)
 	Insert(snapshot model.Snapshot) error
 	Save(snapshot model.Snapshot) error
 	Delete(id string) error
@@ -561,7 +561,7 @@ func (repo *snapshotRepo) FindAllPrevious(fileID string, version int64) ([]model
 	return res, nil
 }
 
-func (repo *snapshotRepo) GetIDsForFile(fileID string) ([]string, error) {
+func (repo *snapshotRepo) GetIDsByFile(fileID string) ([]string, error) {
 	type Value struct {
 		Result string
 	}

--- a/api/repo/task_repo.go
+++ b/api/repo/task_repo.go
@@ -147,8 +147,8 @@ type TaskRepo interface {
 	Insert(opts TaskInsertOptions) (model.Task, error)
 	Find(id string) (model.Task, error)
 	Count() (int64, error)
-	GetCountByEmail(email string) (int64, error)
 	GetIDs(userID string) ([]string, error)
+	GetCountByEmail(email string) (int64, error)
 	Save(task model.Task) error
 	Delete(id string) error
 }

--- a/api/repo/task_repo.go
+++ b/api/repo/task_repo.go
@@ -147,8 +147,8 @@ type TaskRepo interface {
 	Insert(opts TaskInsertOptions) (model.Task, error)
 	Find(id string) (model.Task, error)
 	Count() (int64, error)
+	GetCountByEmail(email string) (int64, error)
 	GetIDs(userID string) ([]string, error)
-	GetCount(email string) (int64, error)
 	Save(task model.Task) error
 	Delete(id string) error
 }
@@ -258,7 +258,7 @@ func (repo *taskRepo) GetIDs(userID string) ([]string, error) {
 	return res, nil
 }
 
-func (repo *taskRepo) GetCount(userID string) (int64, error) {
+func (repo *taskRepo) GetCountByEmail(userID string) (int64, error) {
 	var count int64
 	db := repo.db.
 		Model(&taskEntity{}).

--- a/api/repo/workspace_repo.go
+++ b/api/repo/workspace_repo.go
@@ -32,6 +32,7 @@ type WorkspaceRepo interface {
 	GetIDs() ([]string, error)
 	GetIDsByOrganization(orgID string) ([]string, error)
 	GrantUserPermission(id string, userID string, permission string) error
+	RevokeUserPermission(id string, userID string) error
 }
 
 func NewWorkspaceRepo() WorkspaceRepo {
@@ -307,6 +308,14 @@ func (repo *workspaceRepo) GrantUserPermission(id string, userID string, permiss
               VALUES (?, ?, ?, ?, ?)
               ON CONFLICT (user_id, resource_id) DO UPDATE SET permission = ?`,
 			helper.NewID(), userID, id, permission, helper.NewTimestamp(), permission)
+	if db.Error != nil {
+		return db.Error
+	}
+	return nil
+}
+
+func (repo *workspaceRepo) RevokeUserPermission(id string, userID string) error {
+	db := repo.db.Exec("DELETE FROM userpermission WHERE user_id = ? AND resource_id = ?", userID, id)
 	if db.Error != nil {
 		return db.Error
 	}

--- a/api/router/user_router.go
+++ b/api/router/user_router.go
@@ -81,9 +81,9 @@ func (r *UserRouter) List(c *fiber.Ctx) error {
 		return errorpkg.NewInvalidQueryParamError("sort_order")
 	}
 	userID := GetUserID(c)
-	var nonGroupMembersOnly bool
-	if c.Query("non_group_members_only") != "" {
-		nonGroupMembersOnly, err = strconv.ParseBool(c.Query("non_group_members_only"))
+	var excludeGroupMembers bool
+	if c.Query("exclude_group_members") != "" {
+		excludeGroupMembers, err = strconv.ParseBool(c.Query("exclude_group_members"))
 		if err != nil {
 			return err
 		}
@@ -96,7 +96,7 @@ func (r *UserRouter) List(c *fiber.Ctx) error {
 		Query:               query,
 		OrganizationID:      c.Query("organization_id"),
 		GroupID:             c.Query("group_id"),
-		NonGroupMembersOnly: nonGroupMembersOnly,
+		ExcludeGroupMembers: excludeGroupMembers,
 		SortBy:              sortBy,
 		SortOrder:           sortOrder,
 		Page:                uint(page),

--- a/api/service/group_service.go
+++ b/api/service/group_service.go
@@ -11,12 +11,12 @@
 package service
 
 import (
-	"github.com/kouprlabs/voltaserve/api/errorpkg"
 	"sort"
 	"time"
 
 	"github.com/kouprlabs/voltaserve/api/cache"
 	"github.com/kouprlabs/voltaserve/api/config"
+	"github.com/kouprlabs/voltaserve/api/errorpkg"
 	"github.com/kouprlabs/voltaserve/api/guard"
 	"github.com/kouprlabs/voltaserve/api/helper"
 	"github.com/kouprlabs/voltaserve/api/infra"

--- a/api/service/invitation_service.go
+++ b/api/service/invitation_service.go
@@ -253,9 +253,6 @@ func (svc *InvitationService) Accept(id string, userID string) error {
 	if err := svc.invitationRepo.Save(invitation); err != nil {
 		return err
 	}
-	if err := svc.orgRepo.AddUser(invitation.GetOrganizationID(), userID); err != nil {
-		return err
-	}
 	if err := svc.orgRepo.GrantUserPermission(invitation.GetOrganizationID(), userID, model.PermissionViewer); err != nil {
 		return err
 	}

--- a/api/service/invitation_service.go
+++ b/api/service/invitation_service.go
@@ -77,7 +77,7 @@ func (svc *InvitationService) Create(opts InvitationCreateOptions, userID string
 
 	var emails []string
 
-	/* Collect emails of non existing members and outgoing invitations */
+	/* Collect emails of non-existing members and outgoing invitations */
 	for _, e := range opts.Emails {
 		existing := false
 		for _, u := range orgMembers {

--- a/api/service/organization_service.go
+++ b/api/service/organization_service.go
@@ -247,7 +247,7 @@ func (svc *OrganizationService) RemoveMember(id string, memberID string, userID 
 	}
 
 	/* Revoke permissions from all groups belonging to this organization. */
-	groupsIDs, err := svc.groupRepo.GetIDsForOrganization(org.GetID())
+	groupsIDs, err := svc.groupRepo.GetIDsByOrganization(org.GetID())
 	if err != nil {
 		return err
 	}

--- a/api/service/snapshot_service.go
+++ b/api/service/snapshot_service.go
@@ -132,7 +132,7 @@ func (svc *SnapshotService) List(fileID string, opts SnapshotListOptions, userID
 	if opts.SortOrder == "" {
 		opts.SortOrder = SortOrderAsc
 	}
-	ids, err := svc.snapshotRepo.GetIDsForFile(fileID)
+	ids, err := svc.snapshotRepo.GetIDsByFile(fileID)
 	if err != nil {
 		return nil, err
 	}

--- a/api/service/task_service.go
+++ b/api/service/task_service.go
@@ -278,7 +278,7 @@ func (svc *TaskService) doSorting(data []model.Task, sortBy string, sortOrder st
 func (svc *TaskService) GetCount(userID string) (*int64, error) {
 	var res int64
 	var err error
-	if res, err = svc.taskRepo.GetCount(userID); err != nil {
+	if res, err = svc.taskRepo.GetCountByEmail(userID); err != nil {
 		return nil, err
 	}
 	return &res, nil

--- a/api/service/user_service.go
+++ b/api/service/user_service.go
@@ -54,7 +54,7 @@ type UserListOptions struct {
 	Query               string
 	OrganizationID      string
 	GroupID             string
-	NonGroupMembersOnly bool
+	ExcludeGroupMembers bool
 	SortBy              string
 	SortOrder           string
 	Page                uint
@@ -110,7 +110,7 @@ func (svc *UserService) List(opts UserListOptions, userID string) (*UserList, er
 	res := []model.User{}
 	var err error
 	if opts.Query == "" {
-		if opts.OrganizationID != "" && opts.GroupID != "" && opts.NonGroupMembersOnly {
+		if opts.OrganizationID != "" && opts.GroupID != "" && opts.ExcludeGroupMembers {
 			orgMembers, err := svc.orgRepo.GetMembers(opts.OrganizationID)
 			if err != nil {
 				return nil, err
@@ -120,14 +120,14 @@ func (svc *UserService) List(opts UserListOptions, userID string) (*UserList, er
 				return nil, err
 			}
 			for _, om := range orgMembers {
-				found := false
-				for _, tm := range groupMembers {
-					if om.GetID() == tm.GetID() {
-						found = true
+				isGroupMember := false
+				for _, gm := range groupMembers {
+					if om.GetID() == gm.GetID() {
+						isGroupMember = true
 						break
 					}
 				}
-				if !found {
+				if !isGroupMember {
 					res = append(res, om)
 				}
 			}

--- a/migrations/src/lib.rs
+++ b/migrations/src/lib.rs
@@ -14,6 +14,8 @@ mod m20240718_000007_create_file;
 mod m20240718_000008_create_task;
 mod m20240718_000009_create_grouppermission;
 mod m20240718_000010_create_userpermission;
+mod m20240723_000001_drop_organization_user;
+mod m20240723_000002_drop_group_user;
 
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
@@ -29,6 +31,8 @@ impl MigratorTrait for Migrator {
             Box::new(m20240718_000008_create_task::Migration),
             Box::new(m20240718_000009_create_grouppermission::Migration),
             Box::new(m20240718_000010_create_userpermission::Migration),
+            Box::new(m20240723_000001_drop_organization_user::Migration),
+            Box::new(m20240723_000002_drop_group_user::Migration),
         ]
     }
 }

--- a/migrations/src/m20240723_000001_drop_organization_user.rs
+++ b/migrations/src/m20240723_000001_drop_organization_user.rs
@@ -1,0 +1,24 @@
+use sea_orm_migration::prelude::*;
+
+use crate::models::v1::{OrganizationUser};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(
+        &self,
+        manager: &SchemaManager,
+    ) -> Result<(), DbErr> {
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(OrganizationUser::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/migrations/src/m20240723_000002_drop_group_user.rs
+++ b/migrations/src/m20240723_000002_drop_group_user.rs
@@ -1,0 +1,24 @@
+use sea_orm_migration::prelude::*;
+
+use crate::models::v1::{GroupUser};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(
+        &self,
+        manager: &SchemaManager,
+    ) -> Result<(), DbErr> {
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(GroupUser::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/ui/src/client/api/user.ts
+++ b/ui/src/client/api/user.ts
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the GNU Affero General Public License v3.0 only, included in the file
 // licenses/AGPL.txt.
-
 import useSWR, { SWRConfiguration } from 'swr'
 import { apiFetcher } from '@/client/fetcher'
 
@@ -41,7 +40,7 @@ export type ListOptions = {
   query?: string
   organizationId?: string
   groupId?: string
-  nonGroupMembersOnly?: boolean
+  excludeGroupMembers?: boolean
   size?: number
   page?: number
   sortBy?: SortBy
@@ -56,7 +55,7 @@ type ListQueryParams = {
   query?: string
   organization_id?: string
   group_id?: string
-  non_group_members_only?: string
+  exclude_group_members?: string
 }
 
 export default class UserAPI {
@@ -87,8 +86,8 @@ export default class UserAPI {
     if (options?.groupId) {
       params.group_id = options.groupId.toString()
     }
-    if (options?.nonGroupMembersOnly) {
-      params.non_group_members_only = options.nonGroupMembersOnly.toString()
+    if (options?.excludeGroupMembers) {
+      params.exclude_group_members = options.excludeGroupMembers.toString()
     }
     if (options?.page) {
       params.page = options.page.toString()

--- a/ui/src/components/common/user-selector.tsx
+++ b/ui/src/components/common/user-selector.tsx
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the GNU Affero General Public License v3.0 only, included in the file
 // licenses/AGPL.txt.
-
 import { useCallback, useEffect, useState } from 'react'
 import {
   Button,
@@ -62,7 +61,7 @@ const UserSelector = ({
       query,
       organizationId,
       groupId,
-      nonGroupMembersOnly,
+      excludeGroupMembers: nonGroupMembersOnly,
       page,
       size: 5,
       sortOrder: SortOrder.Desc,


### PR DESCRIPTION
- fix: can give access to owner
- feat: group and organization membership are now based on permissions - not on derivable data (tables below)
- refactor: add migrations to remove the tables `organization_user` and `group_user`

Owner is now visible in the share dialog:

<img width="1410" src="https://github.com/user-attachments/assets/880b8b51-6583-4c46-9890-b987ed3e03a4">
<br/>
<br/>

Make sure at least one owner is available per organization to avoid dangling data:

<img width="1482" src="https://github.com/user-attachments/assets/50c5a71e-cd24-4b71-98ba-ded4cc954357">
<br/>
<br/>

Make sure at least one owner is available per group to avoid dangling data:

<img width="1436" src="https://github.com/user-attachments/assets/548989d2-2529-4979-b0fc-c68ab19ca030">
<br/>
<br/>

Closes #192