### PR TITLE
fix(ui): change rename key on macOS not to interfere

### DIFF
--- a/ui/src/components/file/file-menu.tsx
+++ b/ui/src/components/file/file-menu.tsx
@@ -348,7 +348,7 @@ const FileMenu = ({
                   <span>Rename</span>
                   {isMacOS ? (
                     <div>
-                      <Kbd>return</Kbd>
+                      <Kbd>⌘</Kbd>+<Kbd>E</Kbd>
                     </div>
                   ) : (
                     <div>

--- a/ui/src/components/file/list/index.tsx
+++ b/ui/src/components/file/list/index.tsx
@@ -157,7 +157,7 @@ const FileList = ({ list, scale }: FileListProps) => {
           dispatch(moveModalDidOpen())
         }
       } else if (
-        (keyName === 'return' && isMacOS()) ||
+        (keyName === 'command+e' && isMacOS()) ||
         (keyName === 'f2' && !isMacOS())
       ) {
         if (selection.length === 1) {
@@ -181,7 +181,7 @@ const FileList = ({ list, scale }: FileListProps) => {
         command+a,ctrl+a,
         command+c,ctrl+c,
         command+x,ctrl+x,
-        return,f2,
+        command+e,f2,
         command+backspace,del`}
       onKeyDown={handleKeyDown}
     >


### PR DESCRIPTION
- fix(ui): apparently, using `return` as a rename key in macOS is interfering with other UI actions, so we bring it back to `command+e`