### PR TITLE
fix(api): group repo query & improve other count queries

### DIFF
--- a/api/repo/file_repo.go
+++ b/api/repo/file_repo.go
@@ -348,17 +348,12 @@ func (repo *fileRepo) DeleteChunk(ids []string) error {
 }
 
 func (repo *fileRepo) Count() (int64, error) {
-	type Result struct {
-		Result int64
-	}
-	var res Result
-	db := repo.db.
-		Raw("SELECT count(*) as result FROM file").
-		Scan(&res)
+	var count int64
+	db := repo.db.Model(&fileEntity{}).Count(&count)
 	if db.Error != nil {
-		return 0, db.Error
+		return -1, db.Error
 	}
-	return res.Result, nil
+	return count, nil
 }
 
 func (repo *fileRepo) GetIDsByWorkspace(workspaceID string) ([]string, error) {
@@ -480,7 +475,7 @@ func (repo *fileRepo) GetItemCount(id string) (int64, error) {
 			id).
 		Scan(&res)
 	if db.Error != nil {
-		return 0, db.Error
+		return -1, db.Error
 	}
 	return res.Result - 1, nil
 }

--- a/api/repo/group_repo.go
+++ b/api/repo/group_repo.go
@@ -181,7 +181,7 @@ func (repo *groupRepo) Count() (int64, error) {
 	var count int64
 	db := repo.db.Model(&groupEntity{}).Count(&count)
 	if db.Error != nil {
-		return 0, db.Error
+		return -1, db.Error
 	}
 	return count, nil
 }
@@ -280,19 +280,14 @@ func (repo *groupRepo) GetMembers(id string) ([]model.User, error) {
 }
 
 func (repo *groupRepo) GetOwnerCount(id string) (int64, error) {
-	type Result struct {
-		Result int64
-	}
-	var res Result
-	db := repo.db.
-		Raw(`SELECT count(*) as result FROM userpermission
-             WHERE resource_id = ? and permission = ?`,
-			id, model.PermissionOwner).
-		Scan(&res)
+	var count int64
+	db := repo.db.Model(&userPermissionEntity{}).
+		Where("resource_id = ? and permission = ?").
+		Count(&count)
 	if db.Error != nil {
-		return 0, db.Error
+		return -1, db.Error
 	}
-	return res.Result, nil
+	return count, nil
 }
 
 func (repo *groupRepo) GrantUserPermission(id string, userID string, permission string) error {

--- a/api/repo/group_repo.go
+++ b/api/repo/group_repo.go
@@ -178,17 +178,12 @@ func (repo *groupRepo) Find(id string) (model.Group, error) {
 }
 
 func (repo *groupRepo) Count() (int64, error) {
-	type Result struct {
-		Result int64
-	}
-	var res Result
-	db := repo.db.
-		Raw("SELECT count(*) as result FROM \"group\"").
-		Scan(&res)
+	var count int64
+	db := repo.db.Model(&groupEntity{}).Count(&count)
 	if db.Error != nil {
 		return 0, db.Error
 	}
-	return res.Result, nil
+	return count, nil
 }
 
 func (repo *groupRepo) GetIDsByFile(fileID string) ([]string, error) {

--- a/api/repo/group_repo.go
+++ b/api/repo/group_repo.go
@@ -183,7 +183,7 @@ func (repo *groupRepo) Count() (int64, error) {
 	}
 	var res Result
 	db := repo.db.
-		Raw("SELECT count(*) as result FROM group").
+		Raw("SELECT count(*) as result FROM \"group\"").
 		Scan(&res)
 	if db.Error != nil {
 		return 0, db.Error

--- a/api/repo/invitation_repo.go
+++ b/api/repo/invitation_repo.go
@@ -164,10 +164,11 @@ func (repo *invitationRepo) GetIncomingCount(email string) (int64, error) {
 	var count int64
 	db := repo.db.
 		Model(&invitationEntity{}).
-		Where("email = ? and status = 'pending'", email).
+		Where("email = ?", email).
+		Where("status = 'pending'").
 		Count(&count)
 	if db.Error != nil {
-		return 0, db.Error
+		return -1, db.Error
 	}
 	return count, nil
 }

--- a/api/repo/organization_repo.go
+++ b/api/repo/organization_repo.go
@@ -167,17 +167,12 @@ func (repo *organizationRepo) Find(id string) (model.Organization, error) {
 }
 
 func (repo *organizationRepo) Count() (int64, error) {
-	type Result struct {
-		Result int64
-	}
-	var res Result
-	db := repo.db.
-		Raw("SELECT count(*) as result FROM organization").
-		Scan(&res)
+	var count int64
+	db := repo.db.Model(&organizationEntity{}).Count(&count)
 	if db.Error != nil {
-		return 0, db.Error
+		return -1, db.Error
 	}
-	return res.Result, nil
+	return count, nil
 }
 
 func (repo *organizationRepo) Save(org model.Organization) error {
@@ -256,19 +251,15 @@ func (repo *organizationRepo) GetGroups(id string) ([]model.Group, error) {
 }
 
 func (repo *organizationRepo) GetOwnerCount(id string) (int64, error) {
-	type Result struct {
-		Result int64
-	}
-	var res Result
-	db := repo.db.
-		Raw(`SELECT count(*) as result FROM userpermission
-             WHERE resource_id = ? and permission = ?`,
-			id, model.PermissionOwner).
-		Scan(&res)
+	var count int64
+	db := repo.db.Model(&userPermissionEntity{}).
+		Where("resource_id = ?", id).
+		Where("permission = ?", model.PermissionOwner).
+		Count(&count)
 	if db.Error != nil {
-		return 0, db.Error
+		return -1, db.Error
 	}
-	return res.Result, nil
+	return count, nil
 }
 
 func (repo *organizationRepo) GrantUserPermission(id string, userID string, permission string) error {

--- a/api/repo/task_repo.go
+++ b/api/repo/task_repo.go
@@ -229,17 +229,12 @@ func (repo *taskRepo) Find(id string) (model.Task, error) {
 }
 
 func (repo *taskRepo) Count() (int64, error) {
-	type Result struct {
-		Result int64
-	}
-	var res Result
-	db := repo.db.
-		Raw("SELECT count(*) as result FROM task").
-		Scan(&res)
+	var count int64
+	db := repo.db.Model(&taskEntity{}).Count(&count)
 	if db.Error != nil {
-		return 0, db.Error
+		return -1, db.Error
 	}
-	return res.Result, nil
+	return count, nil
 }
 
 func (repo *taskRepo) GetIDs(userID string) ([]string, error) {
@@ -267,7 +262,7 @@ func (repo *taskRepo) GetCountByEmail(userID string) (int64, error) {
 		Where("user_id = ?", userID).
 		Count(&count)
 	if db.Error != nil {
-		return 0, db.Error
+		return -1, db.Error
 	}
 	return count, nil
 }

--- a/api/repo/user_repo.go
+++ b/api/repo/user_repo.go
@@ -137,15 +137,10 @@ func (repo *userRepo) FindAll() ([]model.User, error) {
 }
 
 func (repo *userRepo) Count() (int64, error) {
-	type Result struct {
-		Result int64
-	}
-	var res Result
-	db := repo.db.
-		Raw(`SELECT count(*) as result FROM "user"`).
-		Scan(&res)
+	var count int64
+	db := repo.db.Model(&userEntity{}).Count(&count)
 	if db.Error != nil {
-		return 0, db.Error
+		return -1, db.Error
 	}
-	return res.Result, nil
+	return count, nil
 }

--- a/api/repo/workspace_repo.go
+++ b/api/repo/workspace_repo.go
@@ -202,17 +202,12 @@ func (repo *workspaceRepo) Find(id string) (model.Workspace, error) {
 }
 
 func (repo *workspaceRepo) Count() (int64, error) {
-	type Result struct {
-		Result int64
-	}
-	var res Result
-	db := repo.db.
-		Raw("SELECT count(*) as result FROM workspace").
-		Scan(&res)
+	var count int64
+	db := repo.db.Model(&workspaceEntity{}).Count(&count)
 	if db.Error != nil {
-		return 0, db.Error
+		return -1, db.Error
 	}
-	return res.Result, nil
+	return count, nil
 }
 
 func (repo *workspaceRepo) UpdateName(id string, name string) (model.Workspace, error) {


### PR DESCRIPTION
- fix(api): group repo query, was causing a runtime error due to missing parenthese
- refactor(api): use GORM APIs for counting instead of raw queries
- refactor(api): return -1 when a count query fails, instead of 0 which can be misleading